### PR TITLE
Set org.opencontainers.image.source label in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go build -o fusion ./cmd/server/*
 
 # deploy
 FROM debian:12
+LABEL org.opencontainers.image.source="https://github.com/0x2E/fusion"
 RUN apt-get update && apt-get install -y sqlite3 ca-certificates
 WORKDIR /fusion
 COPY --from=be /src/fusion ./


### PR DESCRIPTION
As documented in the OCI Image Format, [org.opencontainers.image.source](https://github.com/opencontainers/image-spec/blob/5325ec48851022d6ded604199a3566254e72842a/annotations.md#L24) identifies an image's source repository. This is purely for documentation purposes. It does however help tools such as [Renovate](https://docs.renovatebot.com/modules/datasource/docker/#description) to find the changelogs when a new Fusion version is released. The changelogs would then be included in the PR Renovate creates.