### PR TITLE
Use the set -e option in scripts.sh

### DIFF
--- a/scripts.sh
+++ b/scripts.sh
@@ -1,13 +1,17 @@
 #!/bin/sh
 
+# Exit on first failure.
+set -e
+
 gen() {
   go generate ./...
 }
 
 test_go() {
-  gen || exit 1
+  gen
   # make some files for embed
-  mkdir -p ./frontend/build && touch ./frontend/build/index.html || exit 1
+  mkdir -p ./frontend/build
+  touch ./frontend/build/index.html
   go test ./...
 }
 
@@ -17,12 +21,14 @@ build() {
   test_go
 
   root=$(pwd)
-  mkdir build
+  mkdir -p ./build
   echo "building frontend"
-  cd ./frontend && npm i && npm run build || exit 1
-  cd $root || exit 1
+  cd ./frontend
+  npm i
+  npm run build
+  cd $root
   echo "building backend"
-  go build -o ./build/fusion ./cmd/server/* || exit 1
+  go build -o ./build/fusion ./cmd/server/*
 }
 
 dev() {


### PR DESCRIPTION
The set -e option tells /bin/sh to exit immediately when any command terminates with a failing exit code. Using this option allows us to simplify a lot of the logic and remove the && and || exit 1 clauses because they're not necessary with set -e.

Further details on `set -e`: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#set