### PR TITLE
Use scripts.sh to build within Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,25 @@
 # build frontend
 FROM node:22 as fe
 WORKDIR /src
-COPY .git frontend ./
-RUN npm i && npm run build
+COPY .git .git/
+COPY frontend ./frontend
+COPY scripts.sh .
+RUN ./scripts.sh build-frontend
 
 # build backend
 FROM golang:1.23 as be
 WORKDIR /src
 COPY . ./
-COPY --from=fe /src/build ./frontend/build/
-RUN go build -o fusion ./cmd/server/*
+COPY --from=fe /src/frontend/build ./frontend/build/
+RUN ./scripts.sh build-backend
 
 # deploy
 FROM debian:12
 LABEL org.opencontainers.image.source="https://github.com/0x2E/fusion"
 RUN apt-get update && apt-get install -y sqlite3 ca-certificates
 WORKDIR /fusion
-COPY --from=be /src/fusion ./
+COPY --from=be /src/build/fusion ./
 EXPOSE 8080
 RUN mkdir /data
 ENV DB="/data/fusion.db"
 CMD [ "./fusion" ]
-

--- a/scripts.sh
+++ b/scripts.sh
@@ -8,6 +8,7 @@ gen() {
 }
 
 test_go() {
+  echo "testing"
   gen
   # make some files for embed
   mkdir -p ./frontend/build
@@ -15,20 +16,25 @@ test_go() {
   go test ./...
 }
 
-build() {
-  echo "testing"
-  gen
-  test_go
-
-  root=$(pwd)
-  mkdir -p ./build
+build_frontend() {
   echo "building frontend"
+  mkdir -p ./build
+  root=$(pwd)
   cd ./frontend
   npm i
   npm run build
   cd $root
+}
+
+build_backend() {
   echo "building backend"
   go build -o ./build/fusion ./cmd/server/*
+}
+
+build() {
+  test_go
+  build_frontend
+  build_backend
 }
 
 dev() {
@@ -45,6 +51,12 @@ case $1 in
   ;;
 "dev")
   dev
+  ;;
+"build-frontend")
+  build_frontend
+  ;;
+"build-backend")
+  build_backend
   ;;
 "build")
   build


### PR DESCRIPTION
Docker currently duplicates the build logic from scripts.sh. It's not a big deal now because it's only a couple of standard lines, but if we want to customize the build in the future, it will be useful to have a single, authoritative build script that all build paths use.