### PR TITLE
Build backend using static linking

### DIFF
--- a/scripts.sh
+++ b/scripts.sh
@@ -28,7 +28,10 @@ build_frontend() {
 
 build_backend() {
   echo "building backend"
-  go build -o ./build/fusion ./cmd/server/*
+  go build \
+    -ldflags '-extldflags "-static"' \
+    -o ./build/fusion \
+    ./cmd/server/*
 }
 
 build() {
@@ -39,7 +42,9 @@ build() {
 
 dev() {
   gen
-  go run ./cmd/server
+  go run \
+    -ldflags '-extldflags "-static"' \
+    ./cmd/server
 }
 
 case $1 in


### PR DESCRIPTION
By default, Go builds with dynamic linking. This has the benefit of allowing the compiled binary to re-use existing libraries on the system, but the drawback is that the binary is less portable, as it won't run on systems that lack the libraries it expects. For example, [the precompiled Fusion binary](https://github.com/0x2E/fusion/releases/tag/v0.8.9) does not run on my NixOS 24.11 system.

Switching to static linking means that fusion can basically run on any Linux system regardless of what libraries are installed. It also will allow us to [change the base Docker image from debian to alpine](https://github.com/0x2E/fusion/commit/9f460a44f83d34266e8bfb880dc0727ca2c99662), resulting in an image that's about 80% smaller:

```text
REPOSITORY              TAG       IMAGE ID       CREATED        SIZE
fusion                  latest    5284da0a4f3c   45 years ago   177MB
fusion-alpine           latest    cc517d82d800   45 years ago   36.2MB
```