### PR TITLE
Rename .env to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# To populate a .env file, copy this file to .env:
+#
+#   cp -n .env.example .env
+
 # Web Server
 HOST="0.0.0.0"
 PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 tmp/
 build/
 dist/
+
+# The .env file may contain secrets, so exclude it from source control.
+.env*
+# .env.example is an exception as it only contains dummy secrets.
+!.env.example

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Fusion can be configured in many ways:
 - Create a `.env` file in the same directory as the binary file, and then copy the items you want to modify into it.
   - NOTE: values in `.env` file can be overwritten by system environment variables.
 
-All configuration items can be found [here](https://github.com/0x2E/fusion/blob/main/.env).
+All configuration items can be found [here](https://github.com/0x2E/fusion/blob/main/.env.example).
 
 ## Credits
 

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -3,13 +3,18 @@ package conf
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/joho/godotenv"
 )
 
-const Debug = false
+const (
+	Debug = false
+
+	dotEnvFilename = ".env"
+)
 
 var Conf struct {
 	Host     string `env:"HOST" envDefault:"0.0.0.0"`
@@ -23,11 +28,13 @@ var Conf struct {
 }
 
 func Load() {
-	if err := godotenv.Load(".env"); err != nil {
+	if err := godotenv.Load(dotEnvFilename); err != nil {
 		if !os.IsNotExist(err) {
 			panic(err)
 		}
-		fmt.Println("cannot find .env, skip")
+		log.Printf("no configuration file found at %s", dotEnvFilename)
+	} else {
+		log.Printf("read configuration from %s", dotEnvFilename)
 	}
 	if err := env.Parse(&Conf); err != nil {
 		panic(err)


### PR DESCRIPTION
It caught me by surprise during development that fusion was reading environment variables from .env, as that's not really clear anywhere.

I think it's a bit of a gotcha, so I added logging to make the behavior clearer, and I renamed the default .env file to .env.example so that the user has to explicitly choose to use a .env file.

Keeping the real .env file out of source control also protects developers from accidentally committing their real password to source control and leaking it by mistake.