### PR TITLE
Use a constant for the session key name

### DIFF
--- a/api/session.go
+++ b/api/session.go
@@ -11,6 +11,8 @@ import (
 
 type Session struct{}
 
+const sessionKeyName = "fusion-client-session"
+
 func (s Session) Create(c echo.Context) error {
 	var req struct {
 		Password string `json:"password" validate:"required"`
@@ -24,7 +26,7 @@ func (s Session) Create(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Wrong password")
 	}
 
-	sess, _ := session.Get("login", c)
+	sess, _ := session.Get(sessionKeyName, c)
 
 	if !conf.Conf.SecureCookie {
 		sess.Options.Secure = false
@@ -40,7 +42,7 @@ func (s Session) Create(c echo.Context) error {
 }
 
 func (s Session) Check(c echo.Context) (bool, error) {
-	sess, err := session.Get("login", c)
+	sess, err := session.Get(sessionKeyName, c)
 	if err != nil {
 		return false, err
 	}
@@ -52,7 +54,7 @@ func (s Session) Check(c echo.Context) (bool, error) {
 }
 
 func (s Session) Delete(c echo.Context) error {
-	sess, err := session.Get("login", c)
+	sess, err := session.Get(sessionKeyName, c)
 	if err != nil {
 		return err
 	}

--- a/api/session.go
+++ b/api/session.go
@@ -11,7 +11,9 @@ import (
 
 type Session struct{}
 
-const sessionKeyName = "fusion-client-session"
+// sessionKeyName is the name of the key in the session store, and it's also the
+// client-visible name of the HTTP cookie for the session.
+const sessionKeyName = "session-token"
 
 func (s Session) Create(c echo.Context) error {
 	var req struct {


### PR DESCRIPTION
We're using a 'magic string' for the echo session key name, which makes it easy for the different instances of the string to go out of sync. Using a named constant makes the intent clear and ensures all copies of the key name in the code stay in sync.