### PR TITLE
Check for error on creating a session

### DIFF
--- a/api/session.go
+++ b/api/session.go
@@ -28,7 +28,10 @@ func (s Session) Create(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Wrong password")
 	}
 
-	sess, _ := session.Get(sessionKeyName, c)
+	sess, err := session.Get(sessionKeyName, c)
+	if err != nil {
+		return err
+	}
 
 	if !conf.Conf.SecureCookie {
 		sess.Options.Secure = false


### PR DESCRIPTION
We are currently ignoring the error when we create a new session for a user. I don't see any reason to ignore the error, as the value of the Session object is undefined unless err == nil.

This change updates the code so that we return an error if `session.Get` returns a non-nil error code.