### PR TITLE
Switch Docker image to use Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,8 @@ COPY --from=fe /src/frontend/build ./frontend/build/
 RUN ./scripts.sh build-backend
 
 # deploy
-FROM debian:12
+FROM alpine:3.21.0
 LABEL org.opencontainers.image.source="https://github.com/0x2E/fusion"
-RUN apt-get update && apt-get install -y sqlite3 ca-certificates
 WORKDIR /fusion
 COPY --from=be /src/build/fusion ./
 EXPOSE 8080

--- a/scripts.sh
+++ b/scripts.sh
@@ -28,7 +28,7 @@ build_frontend() {
 
 build_backend() {
   echo "building backend"
-  go build \
+  CGO_ENABLED=0 go build \
     -ldflags '-extldflags "-static"' \
     -o ./build/fusion \
     ./cmd/server/*


### PR DESCRIPTION
Because of #36 and #37, fusion no longer needs an environment that provides glibc. Because of that, we can switch to the slimmer Alpine Linux base image for the Docker container, which slims down the container by 80%:

```
$ docker images
REPOSITORY              TAG       IMAGE ID       CREATED        SIZE
fusion-alpine           latest    5a82f0e01a3c   45 years ago   37.1MB
fusion-debian           latest    b2d88472f6ef   45 years ago   179MB
```