### PR TITLE
Order items by publication date

### DIFF
--- a/repo/item.go
+++ b/repo/item.go
@@ -48,7 +48,7 @@ func (i Item) List(filter ItemFilter, page, pageSize int) ([]*model.Item, int, e
 		return nil, 0, err
 	}
 
-	err = db.Joins("Feed").Order("items.created_at desc, items.pub_date desc").
+	err = db.Joins("Feed").Order("items.pub_date desc, items.created_at desc").
 		Offset((page - 1) * pageSize).Limit(pageSize).Find(&res).Error
 	return res, int(total), err
 }


### PR DESCRIPTION
I propose reordering the list of items to be primarily based on publication date. Otherwise, if you add a new feed with a long backlog of posts, everything in that feed jumps to the front of your queue, which is probably not what you want.