### PR TITLE
Remove the gen command from scripts.sh

### DIFF
--- a/scripts.sh
+++ b/scripts.sh
@@ -3,13 +3,8 @@
 # Exit on first failure.
 set -e
 
-gen() {
-  go generate ./...
-}
-
 test_go() {
   echo "testing"
-  gen
   # make some files for embed
   mkdir -p ./frontend/build
   touch ./frontend/build/index.html
@@ -41,7 +36,6 @@ build() {
 }
 
 dev() {
-  gen
   go run \
     -ldflags '-extldflags "-static"' \
     ./cmd/server
@@ -50,9 +44,6 @@ dev() {
 case $1 in
 "test")
   test_go
-  ;;
-"gen")
-  gen
   ;;
 "dev")
   dev


### PR DESCRIPTION
I forgot to remove it as part of #39, but this is dead code now and is just a no-op since there are no more `go:generate` directives in the code.