### PR TITLE
Make conf settings read-only

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -61,7 +61,7 @@ func Run() {
 	r.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
 		Timeout: 30 * time.Second,
 	}))
-	r.Use(session.Middleware(sessions.NewCookieStore([]byte(conf.Conf.Password))))
+	r.Use(session.Middleware(sessions.NewCookieStore([]byte(conf.Password()))))
 	r.Pre(middleware.RemoveTrailingSlash())
 	r.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -118,9 +118,9 @@ func Run() {
 	items.DELETE("/:id", itemAPIHandler.Delete)
 
 	var err error
-	addr := fmt.Sprintf("%s:%d", conf.Conf.Host, conf.Conf.Port)
-	if conf.Conf.TLSCert != "" {
-		err = r.StartTLS(addr, conf.Conf.TLSCert, conf.Conf.TLSKey)
+	addr := fmt.Sprintf("%s:%d", conf.Host(), conf.Port())
+	if conf.TLSCert() != "" {
+		err = r.StartTLS(addr, conf.TLSCert(), conf.TLSKey())
 	} else {
 		err = r.Start(addr)
 	}

--- a/api/session.go
+++ b/api/session.go
@@ -24,7 +24,7 @@ func (s Session) Create(c echo.Context) error {
 		return err
 	}
 
-	if req.Password != conf.Conf.Password {
+	if req.Password != conf.Password() {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Wrong password")
 	}
 
@@ -33,7 +33,7 @@ func (s Session) Create(c echo.Context) error {
 		return err
 	}
 
-	if !conf.Conf.SecureCookie {
+	if !conf.SecureCookie() {
 		sess.Options.Secure = false
 		sess.Options.SameSite = http.SameSiteDefaultMode
 	}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -16,16 +16,23 @@ const (
 	dotEnvFilename = ".env"
 )
 
-var Conf struct {
-	Host     string `env:"HOST" envDefault:"0.0.0.0"`
-	Port     int    `env:"PORT" envDefault:"8080"`
-	Password string `env:"PASSWORD"`
-	DB       string `env:"DB" envDefault:"fusion.db"`
-
+var conf struct {
+	Host         string `env:"HOST" envDefault:"0.0.0.0"`
+	Port         int    `env:"PORT" envDefault:"8080"`
+	Password     string `env:"PASSWORD"`
+	DB           string `env:"DB" envDefault:"fusion.db"`
 	SecureCookie bool   `env:"SECURE_COOKIE" envDefault:"false"`
 	TLSCert      string `env:"TLS_CERT"`
 	TLSKey       string `env:"TLS_KEY"`
 }
+
+func Host() string       { return conf.Host }
+func Port() int          { return conf.Port }
+func Password() string   { return conf.Password }
+func DB() string         { return conf.DB }
+func SecureCookie() bool { return conf.SecureCookie }
+func TLSCert() string    { return conf.TLSCert }
+func TLSKey() string     { return conf.TLSKey }
 
 func Load() {
 	if err := godotenv.Load(dotEnvFilename); err != nil {
@@ -36,27 +43,27 @@ func Load() {
 	} else {
 		log.Printf("read configuration from %s", dotEnvFilename)
 	}
-	if err := env.Parse(&Conf); err != nil {
+	if err := env.Parse(&conf); err != nil {
 		panic(err)
 	}
 	if err := validate(); err != nil {
 		panic(err)
 	}
 	if Debug {
-		fmt.Println(Conf)
+		fmt.Println(conf)
 	}
 }
 
 func validate() error {
-	if Conf.Password == "" {
+	if conf.Password == "" {
 		return errors.New("password is required")
 	}
 
-	if (Conf.TLSCert == "") != (Conf.TLSKey == "") {
+	if (conf.TLSCert == "") != (conf.TLSKey == "") {
 		return errors.New("missing TLS cert or key file")
 	}
-	if Conf.TLSCert != "" {
-		Conf.SecureCookie = true
+	if conf.TLSCert != "" {
+		conf.SecureCookie = true
 	}
 
 	return nil

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -15,7 +15,7 @@ var DB *gorm.DB
 
 func Init() {
 	conn, err := gorm.Open(
-		sqlite.Open(conf.Conf.DB),
+		sqlite.Open(conf.DB()),
 		&gorm.Config{TranslateError: true},
 	)
 	if err != nil {


### PR DESCRIPTION
It feels a bit messy that the entire program has write access to the configuration as a shared global object. Shared globals make it more difficult to reason about a program's behavior.

This rewrite reduces the problem a bit by making the shared global state read-only after the client calls conf.Load.