### PR TITLE
Get rid of global state for config

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -61,7 +61,7 @@ func Run() {
 	r.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
 		Timeout: 30 * time.Second,
 	}))
-	r.Use(session.Middleware(sessions.NewCookieStore([]byte(conf.Conf.Password))))
+	r.Use(session.Middleware(sessions.NewCookieStore([]byte(conf.Password()))))
 	r.Pre(middleware.RemoveTrailingSlash())
 	r.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -118,9 +118,9 @@ func Run() {
 	items.DELETE("/:id", itemAPIHandler.Delete)
 
 	var err error
-	addr := fmt.Sprintf("%s:%d", conf.Conf.Host, conf.Conf.Port)
-	if conf.Conf.TLSCert != "" {
-		err = r.StartTLS(addr, conf.Conf.TLSCert, conf.Conf.TLSKey)
+	addr := fmt.Sprintf("%s:%d", conf.Host(), conf.Port())
+	if conf.TLSCert() != "" {
+		err = r.StartTLS(addr, conf.TLSCert(), conf.TLSKey())
 	} else {
 		err = r.Start(addr)
 	}

--- a/api/session.go
+++ b/api/session.go
@@ -24,7 +24,7 @@ func (s Session) Create(c echo.Context) error {
 		return err
 	}
 
-	if req.Password != conf.Conf.Password {
+	if req.Password != conf.Password() {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Wrong password")
 	}
 
@@ -33,7 +33,7 @@ func (s Session) Create(c echo.Context) error {
 		return err
 	}
 
-	if !conf.Conf.SecureCookie {
+	if !conf.SecureCookie() {
 		sess.Options.Secure = false
 		sess.Options.SameSite = http.SameSiteDefaultMode
 	}

--- a/api/session.go
+++ b/api/session.go
@@ -3,13 +3,14 @@ package api
 import (
 	"net/http"
 
-	"github.com/0x2e/fusion/conf"
-
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
 )
 
-type Session struct{}
+type Session struct {
+	Password        string
+	UseSecureCookie bool
+}
 
 // sessionKeyName is the name of the key in the session store, and it's also the
 // client-visible name of the HTTP cookie for the session.
@@ -24,7 +25,7 @@ func (s Session) Create(c echo.Context) error {
 		return err
 	}
 
-	if req.Password != conf.Password() {
+	if req.Password != s.Password {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Wrong password")
 	}
 
@@ -33,7 +34,7 @@ func (s Session) Create(c echo.Context) error {
 		return err
 	}
 
-	if !conf.SecureCookie() {
+	if !s.UseSecureCookie {
 		sess.Options.Secure = false
 		sess.Options.SameSite = http.SameSiteDefaultMode
 	}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"net/http"
 	_ "net/http/pprof"
 
@@ -20,10 +21,20 @@ func main() {
 		}()
 	}
 
-	conf.Load()
-	repo.Init()
+	config, err := conf.Load()
+	if err != nil {
+		log.Fatalf("failed to load configuration: %v", err)
+	}
+	repo.Init(config.DB)
 
 	go pull.NewPuller(repo.NewFeed(repo.DB), repo.NewItem(repo.DB)).Run()
 
-	api.Run()
+	api.Run(api.Params{
+		Host:            config.Host,
+		Port:            config.Port,
+		Password:        config.Password,
+		UseSecureCookie: config.SecureCookie,
+		TLSCert:         config.TLSCert,
+		TLSKey:          config.TLSKey,
+	})
 }

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -16,7 +16,7 @@ const (
 	dotEnvFilename = ".env"
 )
 
-var conf struct {
+type Conf struct {
 	Host         string `env:"HOST" envDefault:"0.0.0.0"`
 	Port         int    `env:"PORT" envDefault:"8080"`
 	Password     string `env:"PASSWORD"`
@@ -26,45 +26,33 @@ var conf struct {
 	TLSKey       string `env:"TLS_KEY"`
 }
 
-func Host() string       { return conf.Host }
-func Port() int          { return conf.Port }
-func Password() string   { return conf.Password }
-func DB() string         { return conf.DB }
-func SecureCookie() bool { return conf.SecureCookie }
-func TLSCert() string    { return conf.TLSCert }
-func TLSKey() string     { return conf.TLSKey }
-
-func Load() {
+func Load() (Conf, error) {
 	if err := godotenv.Load(dotEnvFilename); err != nil {
 		if !os.IsNotExist(err) {
-			panic(err)
+			return Conf{}, err
 		}
 		log.Printf("no configuration file found at %s", dotEnvFilename)
 	} else {
 		log.Printf("read configuration from %s", dotEnvFilename)
 	}
+	var conf Conf
 	if err := env.Parse(&conf); err != nil {
-		panic(err)
-	}
-	if err := validate(); err != nil {
 		panic(err)
 	}
 	if Debug {
 		fmt.Println(conf)
 	}
-}
 
-func validate() error {
 	if conf.Password == "" {
-		return errors.New("password is required")
+		return Conf{}, errors.New("password is required")
 	}
 
 	if (conf.TLSCert == "") != (conf.TLSKey == "") {
-		return errors.New("missing TLS cert or key file")
+		return Conf{}, errors.New("missing TLS cert or key file")
 	}
 	if conf.TLSCert != "" {
 		conf.SecureCookie = true
 	}
 
-	return nil
+	return conf, nil
 }

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -16,16 +16,23 @@ const (
 	dotEnvFilename = ".env"
 )
 
-var Conf struct {
-	Host     string `env:"HOST" envDefault:"0.0.0.0"`
-	Port     int    `env:"PORT" envDefault:"8080"`
-	Password string `env:"PASSWORD"`
-	DB       string `env:"DB" envDefault:"fusion.db"`
-
+var conf struct {
+	Host         string `env:"HOST" envDefault:"0.0.0.0"`
+	Port         int    `env:"PORT" envDefault:"8080"`
+	Password     string `env:"PASSWORD"`
+	DB           string `env:"DB" envDefault:"fusion.db"`
 	SecureCookie bool   `env:"SECURE_COOKIE" envDefault:"false"`
 	TLSCert      string `env:"TLS_CERT"`
 	TLSKey       string `env:"TLS_KEY"`
 }
+
+func Host() string       { return conf.Host }
+func Port() int          { return conf.Port }
+func Password() string   { return conf.Password }
+func DB() string         { return conf.DB }
+func SecureCookie() bool { return conf.SecureCookie }
+func TLSCert() string    { return conf.TLSCert }
+func TLSKey() string     { return conf.TLSKey }
 
 func Load() {
 	if err := godotenv.Load(dotEnvFilename); err != nil {
@@ -36,27 +43,27 @@ func Load() {
 	} else {
 		log.Printf("read configuration from %s", dotEnvFilename)
 	}
-	if err := env.Parse(&Conf); err != nil {
+	if err := env.Parse(&conf); err != nil {
 		panic(err)
 	}
 	if err := validate(); err != nil {
 		panic(err)
 	}
 	if Debug {
-		fmt.Println(Conf)
+		fmt.Println(conf)
 	}
 }
 
 func validate() error {
-	if Conf.Password == "" {
+	if conf.Password == "" {
 		return errors.New("password is required")
 	}
 
-	if (Conf.TLSCert == "") != (Conf.TLSKey == "") {
+	if (conf.TLSCert == "") != (conf.TLSKey == "") {
 		return errors.New("missing TLS cert or key file")
 	}
-	if Conf.TLSCert != "" {
-		Conf.SecureCookie = true
+	if conf.TLSCert != "" {
+		conf.SecureCookie = true
 	}
 
 	return nil

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"log"
 
-	"github.com/0x2e/fusion/conf"
 	"github.com/0x2e/fusion/model"
 
 	"github.com/glebarez/sqlite"
@@ -13,9 +12,9 @@ import (
 
 var DB *gorm.DB
 
-func Init() {
+func Init(dbPath string) {
 	conn, err := gorm.Open(
-		sqlite.Open(conf.DB()),
+		sqlite.Open(dbPath),
 		&gorm.Config{TranslateError: true},
 	)
 	if err != nil {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -15,7 +15,7 @@ var DB *gorm.DB
 
 func Init() {
 	conn, err := gorm.Open(
-		sqlite.Open(conf.Conf.DB),
+		sqlite.Open(conf.DB()),
 		&gorm.Config{TranslateError: true},
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes #47

This refactors how we manage the configuration settings. Instead of loading them in `conf` and then sharing a variable in `conf` as global state, we read the configuration once from the `main` package and then pass the settings directly to the packages that consume them.

This makes it easier to reason about the code, as there is no more global state for configuration.