### PR TITLE
Tell browser to delete invalid session tokens

### DIFF
--- a/api/session.go
+++ b/api/session.go
@@ -47,8 +47,17 @@ func (s Session) Create(c echo.Context) error {
 }
 
 func (s Session) Check(c echo.Context) error {
-	_, err := session.Get(sessionKeyName, c)
-	return err
+	sess, err := session.Get(sessionKeyName, c)
+	if err != nil {
+		// If the session token is invalid, advise the client browser to delete the
+		// session token cookie.
+		sess.Options.MaxAge = -1
+		// Deliberately swallow the error because we're already returning a more
+		// important error.
+		sess.Save(c.Request(), c.Response())
+		return err
+	}
+	return nil
 }
 
 func (s Session) Delete(c echo.Context) error {


### PR DESCRIPTION
Currently, if the user logs in to the server with the correct password, they get a cookie called session-token. If the server's password changes, the server (correctly) responds with an HTTP 401 Unauthorized when the user tries to use the token associated with the old password.

The problem is that the server's HTTP 401 response doesn't tell the client's browser to delete the old session token cookie, so it keeps sending it on every request even though the server knows it's bad.

Currently, it doesn't cause any noticeable problems, but I'm working on a change that will affect the data that we store in the session token, so it can lock the user out even if they have the same password because the password will be correct but they'll be using a session token that's invalid.