### PR TITLE
Check passwords based on hashes rather than plaintext

### DIFF
--- a/api/session.go
+++ b/api/session.go
@@ -3,12 +3,13 @@ package api
 import (
 	"net/http"
 
+	"github.com/0x2e/fusion/auth"
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
 )
 
 type Session struct {
-	Password        string
+	PasswordHash    auth.HashedPassword
 	UseSecureCookie bool
 }
 
@@ -25,7 +26,12 @@ func (s Session) Create(c echo.Context) error {
 		return err
 	}
 
-	if req.Password != s.Password {
+	attemptedPasswordHash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Invalid password")
+	}
+
+	if correctPasswordHash := s.PasswordHash; !attemptedPasswordHash.Equals(correctPasswordHash) {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Wrong password")
 	}
 

--- a/auth/password.go
+++ b/auth/password.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"errors"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+var ErrPasswordTooShort = errors.New("password must be non-empty")
+
+type HashedPassword struct {
+	hash []byte
+}
+
+func (hp HashedPassword) Bytes() []byte {
+	return hp.hash
+}
+
+func (hp HashedPassword) Equals(other HashedPassword) bool {
+	return subtle.ConstantTimeCompare(hp.hash, other.hash) != 0
+}
+
+func HashPassword(password string) (HashedPassword, error) {
+	if len(password) == 0 {
+		return HashedPassword{}, ErrPasswordTooShort
+	}
+
+	// These bytes are chosen at random. It's insecure to use a static salt to
+	// hash a set of passwords, but since we're only ever hashing a single
+	// password, using a static salt is fine. The salt prevents an attacker from
+	// using a rainbow table to retrieve the plaintext password from the hashed
+	// version, and that's all that's necessary for fusion's needs.
+	staticSalt := []byte{36, 129, 1, 54}
+	iter := 100
+	keyLen := 32
+	hash := pbkdf2.Key([]byte(password), staticSalt, iter, keyLen, sha256.New)
+
+	return HashedPassword{
+		hash: hash,
+	}, nil
+}

--- a/auth/password_test.go
+++ b/auth/password_test.go
@@ -1,0 +1,71 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/0x2e/fusion/auth"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashPassword(t *testing.T) {
+	for _, tt := range []struct {
+		explanation string
+		input       string
+		wantErr     error
+	}{
+		{
+			explanation: "valid password succeeds",
+			input:       "mypassword",
+			wantErr:     nil,
+		},
+		{
+			explanation: "empty password returns ErrPasswordTooShort",
+			input:       "",
+			wantErr:     auth.ErrPasswordTooShort,
+		},
+	} {
+		t.Run(tt.explanation, func(t *testing.T) {
+			got, err := auth.HashPassword(tt.input)
+			require.Equal(t, tt.wantErr, err)
+			if tt.wantErr == nil {
+				assert.NotEmpty(t, got.Bytes())
+			}
+		})
+	}
+}
+
+func TestHashedPasswordEquals(t *testing.T) {
+	for _, tt := range []struct {
+		explanation     string
+		hashedPassword1 auth.HashedPassword
+		hashedPassword2 auth.HashedPassword
+		want            bool
+	}{
+		{
+			explanation:     "same passwords match",
+			hashedPassword1: mustHashPassword("password1"),
+			hashedPassword2: mustHashPassword("password1"),
+			want:            true,
+		},
+		{
+			explanation:     "different passwords don't match",
+			hashedPassword1: mustHashPassword("password1"),
+			hashedPassword2: mustHashPassword("password2"),
+			want:            false,
+		},
+	} {
+		t.Run(tt.explanation, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.hashedPassword1.Equals(tt.hashedPassword2))
+		})
+	}
+}
+
+func mustHashPassword(password string) auth.HashedPassword {
+	hashedPassword, err := auth.HashPassword(password)
+	if err != nil {
+		panic(err)
+	}
+	return hashedPassword
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -32,7 +32,7 @@ func main() {
 	api.Run(api.Params{
 		Host:            config.Host,
 		Port:            config.Port,
-		Password:        config.Password,
+		PasswordHash:    config.PasswordHash,
 		UseSecureCookie: config.SecureCookie,
 		TLSCert:         config.TLSCert,
 		TLSKey:          config.TLSKey,


### PR DESCRIPTION
fusion's current password mechanism is vulnerable to a timing attack:

https://en.wikipedia.org/wiki/Timing_attack

Because fusion checks passwords using simple [character-by-character string comparison](https://github.com/0x2E/fusion/blob/28d360a4e1b9876b38b4fcf251bff9d6de31f21b/api/session.go#L28), a password attempt that begins with the correct characters will take longer to evaluate than one that starts with incorrect characters. For example, if the correct password is `platypus123` then a password attempt of `plates` will take longer to evaluate than `spoons` because `plates` and `platypus` share a common prefix. An attacker who attempts the password `plates` will know that they likely have the correct prefix. The attacker can continue measuring timing of new password attempts and figure out, character by character, the correct password.

To prevent the timing attack, this change hashes the user's password using PBKDF2 and compares hashes using [`subtle.ConstantTimeCompare`](https://pkg.go.dev/crypto/subtle#ConstantTimeCompare), which is specifically designed to prevent timing attacks.