### PR TITLE
Fix a session checking bug

### DIFF
--- a/api/session.go
+++ b/api/session.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/0x2e/fusion/auth"
@@ -63,6 +64,13 @@ func (s Session) Check(c echo.Context) error {
 		sess.Save(c.Request(), c.Response())
 		return err
 	}
+
+	// If IsNew is true, it means that Get created a new session on-demand rather
+	// than retrieving a previously authenticated session.
+	if sess.IsNew {
+		return errors.New("invalid session")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Resolves #53

This fixes a bug I accidentally introduced by misunderstanding the echo session package. I thought that calling session.Get would return an error if no session existed for the session token valule. It seems that instead, if a session doesn't exist, session.Get creates one on-demand.

To fix this, we have to check the IsNew field of the session to see if calling session.Get created this session on-demand or if this was a session that was previously created in the Create function.

I introduced this bug in #43.