### PR TITLE
fix: redirect to page 1 when use changes feeds

### DIFF
--- a/frontend/src/lib/components/ItemList.svelte
+++ b/frontend/src/lib/components/ItemList.svelte
@@ -82,6 +82,7 @@
 			selected={filter.feed_id}
 			onSelectedChange={(id: number | undefined) => {
 				filter.feed_id = id;
+				filter.page = 1;
 				applyFilter();
 			}}
 			className="w-full md:w-[200px]"


### PR DESCRIPTION
This MR fixes [4] from #55 
- Fixes the pagination bug.
  - When you select a feed for eg. feed A with 10 pages, and you are on the 10th page.
  - Then you change the feed to another feed B, which has only 5 pages.
  - The state remains in page 10 because of Feed A, and shows empty UI for feed B since it doesn't have 10th page.

[Before vs After](https://github.com/user-attachments/assets/4cd9a6d7-494c-4370-8084-6fff188bca47)






