### PR TITLE
fix: improve pagination button responsiveness

### DIFF
--- a/frontend/src/lib/components/ui/pagination/pagination-next-button.svelte
+++ b/frontend/src/lib/components/ui/pagination/pagination-next-button.svelte
@@ -13,13 +13,16 @@
 </script>
 
 {#snippet Fallback()}
-	<span>Next</span>
+	<span class="hidden md:block">Next</span>
 	<ChevronRight />
 {/snippet}
 
 <PaginationPrimitive.NextButton
 	bind:ref
 	{...restProps}
-	class={cn(buttonVariants({ variant: "ghost", className: "gap-1 pr-2.5" }), className)}
+	class={cn(
+		buttonVariants({ variant: 'ghost', className: 'gap-1 px-0 pr-0 md:px-4 md:pr-2.5' }),
+		className
+	)}
 	children={children || Fallback}
 />

--- a/frontend/src/lib/components/ui/pagination/pagination-next-button.svelte
+++ b/frontend/src/lib/components/ui/pagination/pagination-next-button.svelte
@@ -13,7 +13,7 @@
 </script>
 
 {#snippet Fallback()}
-	<span class="hidden md:block">Next</span>
+	<span class="hidden sm:block">Next</span>
 	<ChevronRight />
 {/snippet}
 

--- a/frontend/src/lib/components/ui/pagination/pagination-prev-button.svelte
+++ b/frontend/src/lib/components/ui/pagination/pagination-prev-button.svelte
@@ -13,13 +13,16 @@
 </script>
 
 {#snippet Fallback()}
-	<span>Previous</span>
 	<ChevronLeft />
+	<span class="hidden md:block">Previous</span>
 {/snippet}
 
 <PaginationPrimitive.PrevButton
 	bind:ref
 	{...restProps}
-	class={cn(buttonVariants({ variant: "ghost", className: "gap-1 pl-2.5" }), className)}
+	class={cn(
+		buttonVariants({ variant: 'ghost', className: 'gap-1 px-0 pl-0 md:px-4 md:pl-2.5' }),
+		className
+	)}
 	children={children || Fallback}
 />

--- a/frontend/src/lib/components/ui/pagination/pagination-prev-button.svelte
+++ b/frontend/src/lib/components/ui/pagination/pagination-prev-button.svelte
@@ -14,7 +14,7 @@
 
 {#snippet Fallback()}
 	<ChevronLeft />
-	<span class="hidden md:block">Previous</span>
+	<span class="hidden sm:block">Previous</span>
 {/snippet}
 
 <PaginationPrimitive.PrevButton


### PR DESCRIPTION
This MR addresses [2] from #55 
- Improves pagination in mobile so it doesn't break down.

This pull request includes updates to the pagination buttons in the `frontend/src/lib/components/ui` directory to improve their responsiveness and styling.


https://github.com/user-attachments/assets/491f45d4-9cb2-4e57-929c-1a629488f898


- Fixes the previous button on larger screens, previously (no pun intended) it used to look like this
<img width="105" alt="Screenshot 2025-02-11 at 9 11 40 PM" src="https://github.com/user-attachments/assets/c2701536-1444-4c40-8868-7019d46ca49b" />
