### PR TITLE
Rename Item.Creates to Item.Insert

### DIFF
--- a/repo/item.go
+++ b/repo/item.go
@@ -59,7 +59,7 @@ func (i Item) Get(id uint) (*model.Item, error) {
 	return &res, err
 }
 
-func (i Item) Creates(items []*model.Item) error {
+func (i Item) Insert(items []*model.Item) error {
 	// limit batchSize to fix 'too many SQL variable' error
 	now := time.Now()
 	for _, i := range items {

--- a/service/pull/handle.go
+++ b/service/pull/handle.go
@@ -66,7 +66,7 @@ func (p *Puller) do(ctx context.Context, f *model.Feed, force bool) error {
 				FeedID:  f.ID,
 			})
 		}
-		if err := p.itemRepo.Creates(data); err != nil {
+		if err := p.itemRepo.Insert(data); err != nil {
 			return err
 		}
 	}

--- a/service/pull/pull.go
+++ b/service/pull/pull.go
@@ -24,7 +24,7 @@ type FeedRepo interface {
 }
 
 type ItemRepo interface {
-	Creates(items []*model.Item) error
+	Insert(items []*model.Item) error
 }
 
 type Puller struct {


### PR DESCRIPTION
The verb 'Creates' is a bit inconsistent with the other verbs we're using like List, Get, and Update. Those are all imperative, whereas Creates is simple present tense. I think 'Insert' is the more appropriate name, as it's imperative and describes the action. 'Create' sounds as though it creates a single thing, whereas 'Insert' properly communicates that it can insert one or many.