### PR TITLE
Rename pull.FetchFeeds to FetchFeed

### DIFF
--- a/server/feed.go
+++ b/server/feed.go
@@ -121,7 +121,7 @@ func (f Feed) Create(ctx context.Context, req *ReqFeedCreate) error {
 func (f Feed) CheckValidity(ctx context.Context, req *ReqFeedCheckValidity) (*RespFeedCheckValidity, error) {
 	link := req.Link
 	validLinks := make([]ValidityItem, 0)
-	parsed, err := pull.FetchFeeds(ctx, &model.Feed{Link: &link})
+	parsed, err := pull.FetchFeed(ctx, &model.Feed{Link: &link})
 	if err == nil && parsed != nil {
 		validLinks = append(validLinks, ValidityItem{
 			Title: &parsed.Title,

--- a/service/pull/handle.go
+++ b/service/pull/handle.go
@@ -33,7 +33,7 @@ func (p *Puller) do(ctx context.Context, f *model.Feed, force bool) error {
 	}
 
 	failure := ""
-	fetched, err := FetchFeeds(ctx, f)
+	fetched, err := FetchFeed(ctx, f)
 	if err != nil {
 		failure = err.Error()
 		p.feedRepo.Update(f.ID, &model.Feed{Failure: &failure})
@@ -77,7 +77,7 @@ func (p *Puller) do(ctx context.Context, f *model.Feed, force bool) error {
 	})
 }
 
-func FetchFeeds(ctx context.Context, f *model.Feed) (*gofeed.Feed, error) {
+func FetchFeed(ctx context.Context, f *model.Feed) (*gofeed.Feed, error) {
 	resp, err := httpx.FusionRequest(ctx, *f.Link, &f.FeedRequestOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If I understand correctly, the function fetches a single feed, so the name should be FetchFeed to reflect the function's purpose.