### PR TITLE
Add tests for deciding whether to update a feed

### DIFF
--- a/service/pull/handle_test.go
+++ b/service/pull/handle_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mmcdole/gofeed"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,104 @@ type mockReadCloser struct {
 	result string
 	errMsg string
 	reader *strings.Reader
+}
+
+func TestDecideFeedUpdateAction(t *testing.T) {
+	makeStringPtr := func(s string) *string {
+		return &s
+	}
+	makeBoolPtr := func(b bool) *bool {
+		return &b
+	}
+
+	// Helper function to parse ISO8601 string to time.Time.
+	parseTime := func(iso8601 string) time.Time {
+		t, err := time.Parse(time.RFC3339, iso8601)
+		if err != nil {
+			panic(err)
+		}
+		return t
+	}
+
+	for _, tt := range []struct {
+		description        string
+		currentTime        time.Time
+		feed               model.Feed
+		expectedAction     pull.FeedUpdateAction
+		expectedSkipReason *pull.FeedSkipReason
+	}{
+		{
+			description: "suspended feed should skip update",
+			currentTime: parseTime("2025-01-01T12:00:00Z"),
+			feed: model.Feed{
+				Suspended: makeBoolPtr(true),
+				UpdatedAt: parseTime("2025-01-01T12:00:00Z"),
+			},
+			expectedAction:     pull.ActionSkipUpdate,
+			expectedSkipReason: &pull.SkipReasonSuspended,
+		},
+		{
+			description: "failed feed should skip update",
+			currentTime: parseTime("2025-01-01T12:00:00Z"),
+			feed: model.Feed{
+				Failure:   makeStringPtr("dummy previous error"),
+				Suspended: makeBoolPtr(false),
+				UpdatedAt: parseTime("2025-01-01T12:00:00Z"),
+			},
+			expectedAction:     pull.ActionSkipUpdate,
+			expectedSkipReason: &pull.SkipReasonLastUpdateFailed,
+		},
+		{
+			description: "recently updated feed should skip update",
+			currentTime: parseTime("2025-01-01T12:00:00Z"),
+			feed: model.Feed{
+				Failure:   makeStringPtr(""),
+				Suspended: makeBoolPtr(false),
+				UpdatedAt: parseTime("2025-01-01T11:45:00Z"), // 15 minutes before current time
+			},
+			expectedAction:     pull.ActionSkipUpdate,
+			expectedSkipReason: &pull.SkipReasonTooSoon,
+		},
+		{
+			description: "feed should be updated when conditions are met",
+			currentTime: parseTime("2025-01-01T12:00:00Z"),
+			feed: model.Feed{
+				Failure:   makeStringPtr(""),
+				Suspended: makeBoolPtr(false),
+				UpdatedAt: parseTime("2025-01-01T11:15:00Z"), // 45 minutes before current time
+			},
+			expectedAction:     pull.ActionFetchUpdate,
+			expectedSkipReason: nil,
+		},
+		{
+			description: "feed with nil failure should be updated",
+			currentTime: parseTime("2025-01-01T12:00:00Z"),
+			feed: model.Feed{
+				Failure:   nil,
+				Suspended: makeBoolPtr(false),
+				UpdatedAt: parseTime("2025-01-01T11:15:00Z"), // 45 minutes before current time
+			},
+			expectedAction:     pull.ActionFetchUpdate,
+			expectedSkipReason: nil,
+		},
+		{
+			description: "feed with nil suspended should be updated",
+			currentTime: parseTime("2025-01-01T12:00:00Z"),
+			feed: model.Feed{
+				Failure:   makeStringPtr(""),
+				Suspended: nil,
+				UpdatedAt: parseTime("2025-01-01T11:15:00Z"), // 45 minutes before current time
+			},
+			expectedAction:     pull.ActionFetchUpdate,
+			expectedSkipReason: nil,
+		},
+	} {
+		t.Run(tt.description, func(t *testing.T) {
+			action, skipReason := pull.DecideFeedUpdateAction(&tt.feed, tt.currentTime)
+			assert.Equal(t, tt.expectedAction, action)
+			assert.Equal(t, tt.expectedSkipReason, skipReason)
+		})
+	}
 }
 
 func (m *mockReadCloser) Read(p []byte) (n int, err error) {


### PR DESCRIPTION
There's some complexity to deciding whether or not to update a feed, and there will be even more if we add support for things like honoring the Retry-After response header. I thought it would be helpful to extract the decision to a dedicated function so that we can unit test it.

Note that this change adjusts the decision logic slightly. Previously, we'd skip a suspended feed even if the force parameter was set to true. Now, we'll check a suspended feed if the force parameter was true. I don't think this actually changes anything because it doesn't seem like the user can force a refresh on a suspended feed, but I just wanted to call attention to the change.