### PR TITLE
Pull version string detection out of the frontend build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 // for vite extracting git tag/hash
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
       - name: Build FE
         run: |
-          ./scripts.sh build-frontend
+          # Extract version from git tag (remove 'v' prefix).
+          VERSION=${GITHUB_REF#refs/tags/v}
+          FUSION_VERSION=$VERSION ./scripts.sh build-frontend
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,14 +1,12 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { execSync } from 'child_process';
 import { defineConfig } from 'vite';
+import * as process from 'process';
 
 export default defineConfig({
 	plugins: [sveltekit()],
 	define: {
 		'import.meta.env.FUSION': JSON.stringify({
-			version:
-				execSync('git describe --tags --abbrev=0').toString().trimEnd() ||
-				execSync('git rev-parse --short HEAD').toString().trimEnd()
+			version: process.env.VITE_FUSION_VERSION || 'unknown-version'
 		})
 	},
 	server: {

--- a/scripts.sh
+++ b/scripts.sh
@@ -15,9 +15,23 @@ build_frontend() {
   echo "building frontend"
   mkdir -p ./build
   root=$(pwd)
+
+  if [ -n "$FUSION_VERSION" ]; then
+    version="$FUSION_VERSION"
+  else
+    # Try to get version relative to the last git tag.
+    if git describe --tags --abbrev=0 >/dev/null 2>&1; then
+      version=$(git describe --tags --abbrev=0)
+    else
+      # If repo has no tags, just use the latest commit hash.
+      version=$(git rev-parse --short HEAD)
+    fi
+  fi
+  echo "Using fusion version string: ${version}"
+
   cd ./frontend
   npm i
-  npm run build
+  VITE_FUSION_VERSION="$version" npm run build
   cd $root
 }
 


### PR DESCRIPTION
This moves the logic for determining fusion's version string from git-based checks within the frontend build to outer-level build scripts.

It's tripped me up a few times that version string generation happens in the Vite build.

When someone forks a repo, they don't have the tags, so when they run `./scripts.sh build`, the build will fail with a confusing error about git describe.

This change adjusts the logic so that we determine the fusion version string in `scripts.sh` and in the `release.yml` workflow. It also makes it so that if no version string is available, the frontend defaults to 'unknown-version', which should prevent unnecessary headaches when running vite in dev mode.

This should also make it easier for distributions that want to package fusion, as they previously had to apply workarounds to avoid issues related to deriving the version from git:

https://github.com/NixOS/nixpkgs/pull/353616/files#diff-bf194e560f79450a8df2281184c901a7cab6f5da1e25b3b20ec7767e9482ad1e