### PR TITLE
feat: add `ItemActionVisitLink` to `ItemList`

### DIFF
--- a/frontend/src/lib/components/ItemList.svelte
+++ b/frontend/src/lib/components/ItemList.svelte
@@ -6,6 +6,7 @@
 	import type { Item } from '$lib/api/model';
 	import ItemActionBookmark from './ItemActionBookmark.svelte';
 	import ItemActionUnread from './ItemActionUnread.svelte';
+	import ItemActionVisitLink from './ItemActionVisitLink.svelte';
 	import Pagination from './Pagination.svelte';
 
 	interface Props {
@@ -80,6 +81,7 @@
 					>
 						<ItemActionUnread data={item} />
 						<ItemActionBookmark data={item} />
+						<ItemActionVisitLink data={item} />
 					</div>
 				</a>
 			</li>


### PR DESCRIPTION
A workflow I've been relying on before the redesign was opening multiple tabs from the feed with <kbd>Ctrl</kbd>+<kbd>Left Click</kbd>. The redesign removed the `Visit Original Link` button with no apparent reason so I am re-introducing it with this PR.


| Before | After |
|-----------|---------|
|![Screenshot From 2025-03-14 10-13-21](https://github.com/user-attachments/assets/8e778c01-cfa1-4625-b124-1b6c7e6dee47)|![Screenshot From 2025-03-14 10-13-15](https://github.com/user-attachments/assets/dd507cb7-0962-44aa-a675-5444fea6be06)|