### PR TITLE
feat: improve favicon logic for rsshub

### DIFF
--- a/frontend/src/lib/api/favicon.ts
+++ b/frontend/src/lib/api/favicon.ts
@@ -1,4 +1,33 @@
+/**
+ *  RSSHub paths mapped to their respective hostname.
+ *  Sorted by hostname first then by RSSHub path.
+ */
+const rssHubMap = {
+	'/papers/category/arxiv': 'arxiv.org',
+	'/trendingpapers/papers': 'arxiv.org',
+	'/github': 'github.com',
+	'/google': 'google.com',
+	'/dockerhub': 'hub.docker.com',
+	'/imdb': 'imdb.com',
+	'/hackernews': 'news.ycombinator.com',
+	'/phoronix': 'phoronix.com',
+	'/rsshub': 'rsshub.app',
+	'/twitch': 'twitch.tv',
+	'/youtube': 'youtube.com'
+};
+
 export function getFavicon(feedLink: string): string {
-	const domain = new URL(feedLink).hostname;
-	return 'https://www.google.com/s2/favicons?sz=32&domain=' + domain;
+	const url = new URL(feedLink);
+	let hostname = url.hostname;
+
+	if (hostname.includes('rsshub')) {
+		for (const prefix in rssHubMap) {
+			if (url.pathname.startsWith(prefix)) {
+				hostname = rssHubMap[prefix as keyof typeof rssHubMap];
+				break;
+			}
+		}
+	}
+
+	return 'https://www.google.com/s2/favicons?sz=32&domain=' + hostname;
 }


### PR DESCRIPTION
This PR allows [RSSHub](https://docs.rsshub.app/) feeds to show their original favicon instead of a placeholder. I've only added a handful of sites I regularly visit, but it should be trivial for someone else to add more.

|Before|After|
|-|-|
|![Screenshot From 2025-03-14 15-11-43](https://github.com/user-attachments/assets/c0c7b726-8754-4c20-8dba-e8b9126645b7)|![Screenshot From 2025-03-14 15-11-47](https://github.com/user-attachments/assets/b91bdd9c-ae0f-45a1-b43e-9e332c525a2d)|


