### PR TITLE
Treat update time as feed build time consistently

### DIFF
--- a/service/pull/handle.go
+++ b/service/pull/handle.go
@@ -74,7 +74,7 @@ func (p *Puller) do(ctx context.Context, f *model.Feed, force bool) error {
 	}
 	logger.Infof("fetched %d items", len(fetched.Items))
 	return p.feedRepo.Update(f.ID, &model.Feed{
-		LastBuild: fetched.PublishedParsed,
+		LastBuild: fetched.UpdatedParsed,
 		Failure:   ptr.To(""),
 	})
 }


### PR DESCRIPTION
In Puller.do, we decide isLatestBuild by comparing the feed's stored LastBuild field to the fetched UpdatedParsed value, but then at the end of the function, we store PublishedParsed as the LastBuild time for the feed.

This appears to be an error, so this change makes it so that we consistently use the fetched feed's UpdateParsed field as the value of the LastBuild.