### PR TITLE
feat: add counters to sidebar

### DIFF
--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -20,23 +20,28 @@
 	interface Props {
 		feeds: Feed[];
 		groups: Group[];
+		unreadCount: number;
 	}
 
-	let { feeds, groups }: Props = $props();
+	let { feeds, groups, unreadCount }: Props = $props();
 
 	const version = import.meta.env.FUSION.version;
 
 	type SystemNavLink = {
 		label: string;
 		url: string;
+		count?: number;
 		icon: typeof Icon;
 	};
-	const systemLinks: SystemNavLink[] = [
-		{ label: 'Unread', url: '/', icon: Inbox },
-		{ label: 'Bookmark', url: '/bookmarks', icon: BookmarkCheck },
-		{ label: 'All', url: '/all', icon: List },
-		{ label: 'Settings', url: '/settings', icon: Settings }
-	];
+	let systemLinks = $state<SystemNavLink[]>([]);
+	$effect(() => {
+		systemLinks = [
+			{ label: 'Unread', url: '/', icon: Inbox, count: unreadCount },
+			{ label: 'Bookmark', url: '/bookmarks', icon: BookmarkCheck },
+			{ label: 'All', url: '/all', icon: List },
+			{ label: 'Settings', url: '/settings', icon: Settings }
+		];
+	});
 
 	function isHighlight(url: string): boolean {
 		let chunks = page.url.pathname.split('/');
@@ -95,15 +100,22 @@
 		<ul class="menu w-full font-medium">
 			{#each systemLinks as v}
 				<li>
-					<a href={v.url} class={isHighlight(v.url) ? 'menu-active' : ''}>
-						<v.icon class="size-4" /><span>{v.label}</span>
+					<a href={v.url} class:menu-active={isHighlight(v.url)} class="flex justify-between">
+						<div class="flex items-center gap-2">
+							<v.icon class="size-4" /><span>{v.label}</span>
+						</div>
+						{#if v.count}
+							<div class="text-slate-400">{v.count}</div>
+						{/if}
 					</a>
 				</li>
 			{/each}
 		</ul>
 
 		<ul class="menu w-full">
-			<li class="menu-title">Feeds</li>
+			<li class="menu-title">
+				{feeds.length > 1 ? `${feeds.length} ` : ''}Feeds
+			</li>
 			{#each groups as group, index}
 				<li>
 					<details open={index === 0}>

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -33,15 +33,12 @@
 		count?: number;
 		icon: typeof Icon;
 	};
-	let systemLinks = $state<SystemNavLink[]>([]);
-	$effect(() => {
-		systemLinks = [
-			{ label: 'Unread', url: '/', icon: Inbox, count: unreadCount },
-			{ label: 'Bookmark', url: '/bookmarks', icon: BookmarkCheck },
-			{ label: 'All', url: '/all', icon: List },
-			{ label: 'Settings', url: '/settings', icon: Settings }
-		];
-	});
+	const systemLinks = $derived<SystemNavLink[]>([
+		{ label: 'Unread', url: '/', icon: Inbox, count: unreadCount },
+		{ label: 'Bookmark', url: '/bookmarks', icon: BookmarkCheck },
+		{ label: 'All', url: '/all', icon: List },
+		{ label: 'Settings', url: '/settings', icon: Settings }
+	]);
 
 	function isHighlight(url: string): boolean {
 		let chunks = page.url.pathname.split('/');

--- a/frontend/src/routes/(authed)/+layout.svelte
+++ b/frontend/src/routes/(authed)/+layout.svelte
@@ -22,7 +22,7 @@
 		<div
 			class="text-base-content bg-base-200 z-50 h-full min-h-full w-[80%] overflow-x-hidden px-2 py-4 lg:w-72"
 		>
-			<Sidebar feeds={data.feeds} groups={data.groups} />
+			<Sidebar feeds={data.feeds} groups={data.groups} unreadCount={data.unreadCount} />
 		</div>
 	</div>
 </div>

--- a/frontend/src/routes/(authed)/+layout.ts
+++ b/frontend/src/routes/(authed)/+layout.ts
@@ -1,13 +1,21 @@
 import { listFeeds } from '$lib/api/feed';
 import { allGroups } from '$lib/api/group';
+import { listItems } from '$lib/api/item';
+import { fullItemFilter } from '$lib/state.svelte';
 import type { LayoutLoad } from './$types';
 
 export const load: LayoutLoad = async () => {
 	const feeds = await listFeeds();
 	const groups = await allGroups();
 	groups.sort((a, b) => a.id - b.id);
+
+	const filter = { unread: true };
+	Object.assign(fullItemFilter, filter);
+	const unreadItems = await listItems(filter);
+
 	return {
 		feeds,
-		groups
+		groups,
+		unreadCount: unreadItems.total
 	};
 };


### PR DESCRIPTION
- A unread counter has been added to the `Unread` link
- A feed counter has been added before the feed group list
- Everything is reactive (i.e. no page refresh needed for the numbers to update)

This is not a trivial change. Please review carefully before merging. To be specific, adding the feed counter was trivial but the unread counter effectively doubles the amount of ListItems API call. It also adds latency to `frontend/src/routes/(authed)/+layout.ts` and makes the `systemLinks` rerender every time the user marks an item as "read". The negative effects were impossible to notice on my end, but I recommend testing them yourself before merging the changes.

|Before|After|
|-|-|
|![Screenshot From 2025-03-15 19-02-15](https://github.com/user-attachments/assets/ab6fa1e4-78f1-47e4-ba0a-3cfef86599ed)|![Screenshot From 2025-03-15 19-02-19](https://github.com/user-attachments/assets/783192f1-1a77-4004-b81e-ec4a4ac000cf)|
