### PR TITLE
refactor: improve `filter` definition readability

### DIFF
--- a/frontend/src/lib/api/item.ts
+++ b/frontend/src/lib/api/item.ts
@@ -24,7 +24,7 @@ export async function listItems(options?: ListFilter) {
 		.json<{ total: number; items: Item[] }>();
 }
 
-export function parseURLtoFilter(params: URLSearchParams): ListFilter {
+export function parseURLtoFilter(params: URLSearchParams, override?: ListFilter): ListFilter {
 	const filter: ListFilter = {
 		page: parseInt(params.get('page') || '1'),
 		page_size: parseInt(params.get('page_size') || String(defaultPageSize))
@@ -37,7 +37,7 @@ export function parseURLtoFilter(params: URLSearchParams): ListFilter {
 	if (unread) filter.unread = unread === 'true';
 	const bookmark = params.get('bookmark');
 	if (bookmark) filter.bookmark = bookmark === 'true';
-	return filter;
+	return { ...filter, ...override };
 }
 
 export function applyFilterToURL(url: URL, filter: ListFilter) {

--- a/frontend/src/routes/(authed)/+page.ts
+++ b/frontend/src/routes/(authed)/+page.ts
@@ -4,12 +4,13 @@ import { fullItemFilter } from '$lib/state.svelte';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ url }) => {
-	const filter = parseURLtoFilter(url.searchParams);
-	filter.unread = true;
-	filter.bookmark = undefined;
+	const filter = parseURLtoFilter(url.searchParams, {
+		unread: true,
+		bookmark: undefined
+	});
 	Object.assign(fullItemFilter, filter);
-	const items = await listItems(filter);
 	const feeds = await listFeeds({ have_unread: true });
+	const items = await listItems(filter);
 	return {
 		feeds: feeds,
 		items: {

--- a/frontend/src/routes/(authed)/all/+page.ts
+++ b/frontend/src/routes/(authed)/all/+page.ts
@@ -4,9 +4,10 @@ import { fullItemFilter } from '$lib/state.svelte';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ url }) => {
-	const filter = parseURLtoFilter(url.searchParams);
-	filter.unread = undefined;
-	filter.bookmark = undefined;
+	const filter = parseURLtoFilter(url.searchParams, {
+		unread: undefined,
+		bookmark: undefined
+	});
 	Object.assign(fullItemFilter, filter);
 	const feeds = await listFeeds();
 	const items = await listItems(filter);

--- a/frontend/src/routes/(authed)/bookmarks/+page.ts
+++ b/frontend/src/routes/(authed)/bookmarks/+page.ts
@@ -4,9 +4,10 @@ import { fullItemFilter } from '$lib/state.svelte';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ url }) => {
-	const filter = parseURLtoFilter(url.searchParams);
-	filter.unread = undefined;
-	filter.bookmark = true;
+	const filter = parseURLtoFilter(url.searchParams, {
+		unread: undefined,
+		bookmark: true
+	});
 	Object.assign(fullItemFilter, filter);
 	const feeds = await listFeeds({ have_bookmark: true });
 	const items = await listItems(filter);

--- a/frontend/src/routes/(authed)/feeds/[id]/+page.ts
+++ b/frontend/src/routes/(authed)/feeds/[id]/+page.ts
@@ -8,8 +8,9 @@ export const prerender = false;
 export const load: PageLoad = async ({ url, params }) => {
 	const id = parseInt(params.id);
 	const feed = getFeed(id);
-	const filter = parseURLtoFilter(url.searchParams);
-	filter.feed_id = id;
+	const filter = parseURLtoFilter(url.searchParams, {
+		feed_id: id
+	});
 	Object.assign(fullItemFilter, filter);
 	const items = listItems(filter);
 	return { feed: feed, items: items };


### PR DESCRIPTION
- reduce modification of `const` variable after its definition
- definition of `filter` happens in single operation rather than multiple