### PR TITLE
feat: improve page load time

### DIFF
--- a/frontend/src/lib/components/ItemActionMarkAllasRead.svelte
+++ b/frontend/src/lib/components/ItemActionMarkAllasRead.svelte
@@ -5,15 +5,25 @@
 	import { CheckCheck } from 'lucide-svelte';
 	import { toast } from 'svelte-sonner';
 
-	interface Props {
-		items: Item[];
-	}
+	type Props =
+		| {
+				disabled: true;
+		  }
+		| {
+				disabled?: false;
+				items: Item[];
+		  };
 
-	let { items }: Props = $props();
+	let props: Props = $props();
 
 	async function handleMarkAllAsRead() {
+		if (props.disabled) {
+			console.error('unreachable code');
+			return;
+		}
+
 		try {
-			const ids = items.map((v) => v.id);
+			const ids = props.items.map((v) => v.id);
 			await updateUnread(ids, false);
 			toast.success('Update successfully');
 			invalidateAll();
@@ -23,8 +33,8 @@
 	}
 </script>
 
-<div class="tooltip tooltip-bottom" data-tip="Mark All as Read">
-	<button onclick={handleMarkAllAsRead} class="btn btn-ghost btn-square">
+<div class="tooltip tooltip-bottom" data-tip={props.disabled ? undefined : 'Mark All as Read'}>
+	<button disabled={props.disabled} onclick={handleMarkAllAsRead} class="btn btn-ghost btn-square">
 		<CheckCheck class="size-4" />
 	</button>
 </div>

--- a/frontend/src/lib/components/ItemListPlaceholder.svelte
+++ b/frontend/src/lib/components/ItemListPlaceholder.svelte
@@ -1,0 +1,12 @@
+<div class="flex flex-col gap-1">
+	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-12 w-full rounded"></div>
+</div>

--- a/frontend/src/lib/components/ItemListPlaceholder.svelte
+++ b/frontend/src/lib/components/ItemListPlaceholder.svelte
@@ -1,7 +1,7 @@
 <div class="flex flex-col gap-1">
-	<div class="skeleton h-12 w-full rounded"></div>
-	<div class="skeleton h-12 w-full rounded"></div>
-	<div class="skeleton h-12 w-full rounded"></div>
-	<div class="skeleton h-12 w-full rounded"></div>
-	<div class="skeleton h-12 w-full rounded"></div>
+	<div class="skeleton h-10 w-full rounded"></div>
+	<div class="skeleton h-10 w-full rounded"></div>
+	<div class="skeleton h-10 w-full rounded"></div>
+	<div class="skeleton h-10 w-full rounded"></div>
+	<div class="skeleton h-10 w-full rounded"></div>
 </div>

--- a/frontend/src/lib/components/ItemListPlaceholder.svelte
+++ b/frontend/src/lib/components/ItemListPlaceholder.svelte
@@ -4,9 +4,4 @@
 	<div class="skeleton h-12 w-full rounded"></div>
 	<div class="skeleton h-12 w-full rounded"></div>
 	<div class="skeleton h-12 w-full rounded"></div>
-	<div class="skeleton h-12 w-full rounded"></div>
-	<div class="skeleton h-12 w-full rounded"></div>
-	<div class="skeleton h-12 w-full rounded"></div>
-	<div class="skeleton h-12 w-full rounded"></div>
-	<div class="skeleton h-12 w-full rounded"></div>
 </div>

--- a/frontend/src/routes/(authed)/+page.svelte
+++ b/frontend/src/routes/(authed)/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ItemActionMarkAllasRead from '$lib/components/ItemActionMarkAllasRead.svelte';
 	import ItemList from '$lib/components/ItemList.svelte';
+	import ItemListPlaceholder from '$lib/components/ItemListPlaceholder.svelte';
 	import PageNavHeader from '$lib/components/PageNavHeader.svelte';
 
 	let { data } = $props();
@@ -12,12 +13,20 @@
 
 <div class="flex flex-col">
 	<PageNavHeader showSearch={true}>
-		<ItemActionMarkAllasRead items={data.items.data} />
+		{#await data.items}
+			<ItemActionMarkAllasRead disabled />
+		{:then items}
+			<ItemActionMarkAllasRead items={items.items} />
+		{/await}
 	</PageNavHeader>
 	<div class="px-4 lg:px-8">
 		<div class="py-6">
 			<h1 class="text-3xl font-bold">Unread</h1>
 		</div>
-		<ItemList items={data.items.data} total={data.items.total} />
+		{#await data.items}
+			<ItemListPlaceholder />
+		{:then items}
+			<ItemList items={items.items} total={items.total} />
+		{/await}
 	</div>
 </div>

--- a/frontend/src/routes/(authed)/+page.ts
+++ b/frontend/src/routes/(authed)/+page.ts
@@ -1,4 +1,3 @@
-import { listFeeds } from '$lib/api/feed';
 import { listItems, parseURLtoFilter } from '$lib/api/item';
 import { fullItemFilter } from '$lib/state.svelte';
 import type { PageLoad } from './$types';
@@ -8,13 +7,7 @@ export const load: PageLoad = async ({ url }) => {
 	filter.unread = true;
 	filter.bookmark = undefined;
 	Object.assign(fullItemFilter, filter);
-	const items = await listItems(filter);
-	const feeds = await listFeeds({ have_unread: true });
 	return {
-		feeds: feeds,
-		items: {
-			total: items.total,
-			data: items.items
-		}
+		items: listItems(filter)
 	};
 };

--- a/frontend/src/routes/(authed)/all/+page.svelte
+++ b/frontend/src/routes/(authed)/all/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import ActionSearch from '$lib/components/ActionSearch.svelte';
 	import ItemList from '$lib/components/ItemList.svelte';
+	import ItemListPlaceholder from '$lib/components/ItemListPlaceholder.svelte';
 	import PageNavHeader from '$lib/components/PageNavHeader.svelte';
 	import type { PageData } from './$types';
 
@@ -21,6 +21,10 @@
 		<div class="py-6">
 			<h1 class="text-3xl font-bold">All</h1>
 		</div>
-		<ItemList items={data.items.data} total={data.items.total} highlightUnread={true} />
+		{#await data.items}
+			<ItemListPlaceholder />
+		{:then items}
+			<ItemList items={items.items} total={items.total} highlightUnread={true} />
+		{/await}
 	</div>
 </div>

--- a/frontend/src/routes/(authed)/all/+page.ts
+++ b/frontend/src/routes/(authed)/all/+page.ts
@@ -1,4 +1,3 @@
-import { listFeeds } from '$lib/api/feed';
 import { listItems, parseURLtoFilter } from '$lib/api/item';
 import { fullItemFilter } from '$lib/state.svelte';
 import type { PageLoad } from './$types';
@@ -8,13 +7,8 @@ export const load: PageLoad = async ({ url }) => {
 	filter.unread = undefined;
 	filter.bookmark = undefined;
 	Object.assign(fullItemFilter, filter);
-	const feeds = await listFeeds();
-	const items = await listItems(filter);
+
 	return {
-		feeds: feeds,
-		items: {
-			total: items.total,
-			data: items.items
-		}
+		items: listItems(filter)
 	};
 };

--- a/frontend/src/routes/(authed)/bookmarks/+page.svelte
+++ b/frontend/src/routes/(authed)/bookmarks/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ItemList from '$lib/components/ItemList.svelte';
+	import ItemListPlaceholder from '$lib/components/ItemListPlaceholder.svelte';
 	import PageNavHeader from '$lib/components/PageNavHeader.svelte';
 	import type { PageData } from './$types';
 
@@ -20,6 +21,10 @@
 		<div class="py-6">
 			<h1 class="text-3xl font-bold">Bookmark</h1>
 		</div>
-		<ItemList items={data.items.data} total={data.items.total} />
+		{#await data.items}
+			<ItemListPlaceholder />
+		{:then items}
+			<ItemList items={items.items} total={items.total} />
+		{/await}
 	</div>
 </div>

--- a/frontend/src/routes/(authed)/bookmarks/+page.ts
+++ b/frontend/src/routes/(authed)/bookmarks/+page.ts
@@ -8,13 +8,9 @@ export const load: PageLoad = async ({ url }) => {
 	filter.unread = undefined;
 	filter.bookmark = true;
 	Object.assign(fullItemFilter, filter);
-	const feeds = await listFeeds({ have_bookmark: true });
-	const items = await listItems(filter);
+
 	return {
-		feeds: feeds,
-		items: {
-			total: items.total,
-			data: items.items
-		}
+		feeds: listFeeds({ have_bookmark: true }),
+		items: listItems(filter)
 	};
 };


### PR DESCRIPTION
- removed unused API calls (all were blocking)
- site now shows loading state instead of blocking until everything's loaded (async data fetching)
- `frontend/src/routes/(authed)/feeds/[id]/+page.svelte` has not been touched but I will follow up with another PR in the near future
- this PR was created to offset the performance regression introduced in #81