### PR TITLE
Sort feeds by name

### DIFF
--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -111,7 +111,7 @@
 							<span class="line-clamp-1">{group.name}</span>
 						</summary>
 						<ul>
-							{#each feeds.filter((v) => v.group.id === group.id) as feed}
+							{#each feeds.filter((v) => v.group.id === group.id).sort((a, b) => a.name.localeCompare(b.name)) as feed}
 								{@const domain = new URL(feed.link).hostname}
 								{@const textColor = feed.suspended
 									? 'text-base-content/60'


### PR DESCRIPTION
The feeds by default seem to be ordered by domain, which is not what the user might expect.

This switches the feed to be ordered by feed name.

Fixes #71