### PR TITLE
Remove feed ID from ParseGoFeedItems

### DIFF
--- a/service/pull/handle.go
+++ b/service/pull/handle.go
@@ -47,7 +47,13 @@ func (p *Puller) do(ctx context.Context, f *model.Feed, force bool) error {
 	isLatestBuild := f.LastBuild != nil && fetched.UpdatedParsed != nil &&
 		fetched.UpdatedParsed.Equal(*f.LastBuild)
 	if len(fetched.Items) != 0 && !isLatestBuild {
-		data := ParseGoFeedItems(fetched.Items, f.ID)
+		data := ParseGoFeedItems(fetched.Items)
+
+		// Set the correct feed ID for all items.
+		for _, item := range data {
+			item.FeedID = f.ID
+		}
+
 		if err := p.itemRepo.Insert(data); err != nil {
 			return err
 		}

--- a/service/pull/parse.go
+++ b/service/pull/parse.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mmcdole/gofeed"
 )
 
-func ParseGoFeedItems(gfItems []*gofeed.Item, feedID uint) []*model.Item {
+func ParseGoFeedItems(gfItems []*gofeed.Item) []*model.Item {
 	items := make([]*model.Item, 0, len(gfItems))
 	for _, item := range gfItems {
 		if item == nil {
@@ -29,7 +29,6 @@ func ParseGoFeedItems(gfItems []*gofeed.Item, feedID uint) []*model.Item {
 			Content: &content,
 			PubDate: item.PublishedParsed,
 			Unread:  &unread,
-			FeedID:  feedID,
 		})
 	}
 

--- a/service/pull/parse_test.go
+++ b/service/pull/parse_test.go
@@ -25,7 +25,6 @@ func TestParseGoFeedItems(t *testing.T) {
 	for _, tt := range []struct {
 		description string
 		gfItems     []*gofeed.Item
-		feedID      uint
 		expected    []*model.Item
 	}{
 		{
@@ -40,7 +39,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					PublishedParsed: parseTime("2025-01-01T12:00:00Z"),
 				},
 			},
-			feedID: 42,
 			expected: []*model.Item{
 				{
 					Title:   ptr.To("Test Item"),
@@ -49,7 +47,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					Content: ptr.To("<p>This is the content</p>"),
 					PubDate: parseTime("2025-01-01T12:00:00Z"),
 					Unread:  ptr.To(true),
-					FeedID:  42,
 				},
 			},
 		},
@@ -65,7 +62,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					PublishedParsed: parseTime("2025-01-01T12:00:00Z"),
 				},
 			},
-			feedID: 42,
 			expected: []*model.Item{
 				{
 					Title:   ptr.To("Test Item"),
@@ -74,7 +70,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					Content: ptr.To("This is the description"), // Should use description
 					PubDate: parseTime("2025-01-01T12:00:00Z"),
 					Unread:  ptr.To(true),
-					FeedID:  42,
 				},
 			},
 		},
@@ -90,7 +85,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					PublishedParsed: parseTime("2025-01-01T12:00:00Z"),
 				},
 			},
-			feedID: 42,
 			expected: []*model.Item{
 				{
 					Title:   ptr.To("Test Item"),
@@ -99,7 +93,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					Content: ptr.To("<p>This is the content</p>"),
 					PubDate: parseTime("2025-01-01T12:00:00Z"),
 					Unread:  ptr.To(true),
-					FeedID:  42,
 				},
 			},
 		},
@@ -115,7 +108,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					PublishedParsed: parseTime("2025-01-01T12:00:00Z"),
 				},
 			},
-			feedID: 42,
 			expected: []*model.Item{
 				{
 					Title:   ptr.To("Test Item"),
@@ -124,7 +116,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					Content: ptr.To("This is the description"), // Should use description
 					PubDate: parseTime("2025-01-01T12:00:00Z"),
 					Unread:  ptr.To(true),
-					FeedID:  42,
 				},
 			},
 		},
@@ -148,7 +139,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					PublishedParsed: parseTime("2025-01-01T12:00:00Z"),
 				},
 			},
-			feedID: 42,
 			expected: []*model.Item{
 				{
 					Title:   ptr.To("Item 1"),
@@ -157,7 +147,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					Content: ptr.To("content1"),
 					PubDate: parseTime("2025-01-01T12:00:00Z"),
 					Unread:  ptr.To(true),
-					FeedID:  42,
 				},
 				{
 					Title:   ptr.To("Item 2"),
@@ -166,14 +155,12 @@ func TestParseGoFeedItems(t *testing.T) {
 					Content: ptr.To("content2"),
 					PubDate: parseTime("2025-01-01T12:00:00Z"),
 					Unread:  ptr.To(true),
-					FeedID:  42,
 				},
 			},
 		},
 		{
 			description: "returns empty slice for empty input",
 			gfItems:     []*gofeed.Item{},
-			feedID:      42,
 			expected:    []*model.Item{},
 		},
 		{
@@ -195,7 +182,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					PublishedParsed: parseTime("2025-01-01T12:00:00Z"),
 				},
 			},
-			feedID: 42,
 			expected: []*model.Item{
 				{
 					Title:   ptr.To("Valid Item"),
@@ -204,7 +190,6 @@ func TestParseGoFeedItems(t *testing.T) {
 					Content: ptr.To("valid content"),
 					PubDate: parseTime("2025-01-01T12:00:00Z"),
 					Unread:  ptr.To(true),
-					FeedID:  42,
 				},
 				{
 					Title:   ptr.To("Another Valid Item"),
@@ -213,13 +198,12 @@ func TestParseGoFeedItems(t *testing.T) {
 					Content: ptr.To("another content"),
 					PubDate: parseTime("2025-01-01T12:00:00Z"),
 					Unread:  ptr.To(true),
-					FeedID:  42,
 				},
 			},
 		},
 	} {
 		t.Run(tt.description, func(t *testing.T) {
-			result := pull.ParseGoFeedItems(tt.gfItems, tt.feedID)
+			result := pull.ParseGoFeedItems(tt.gfItems)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
The feed ID doesn't really belong in ParseGoFeedItems because its job is to convert gofeed objects to fusion objects, but the feed ID is not a concept in gofeed.

The only reason we need to store the feed ID in each feed item is so that each feed item references its parent feed in the database, so we should handle populating feed ID with the database logic, not with the gofeed parsing logic.