### PR TITLE
Add FeedClient.FetchDeclaredLink method

### DIFF
--- a/service/pull/client/client.go
+++ b/service/pull/client/client.go
@@ -42,6 +42,20 @@ func (c FeedClient) FetchTitle(ctx context.Context, feedURL string, options mode
 	return feed.Title, nil
 }
 
+// FetchDeclaredLink retrieves the feed link declared within the feed content
+func (c FeedClient) FetchDeclaredLink(ctx context.Context, feedURL string, options model.FeedRequestOptions) (string, error) {
+	feed, err := c.fetchFeed(ctx, feedURL, options)
+	if err != nil {
+		return "", err
+	}
+
+	if feed.FeedLink != "" {
+		return feed.FeedLink, nil
+	}
+
+	return feed.Link, nil
+}
+
 type FetchItemsResult struct {
 	LastBuild *time.Time
 	Items     []*model.Item

--- a/service/sniff/wellknown.go
+++ b/service/sniff/wellknown.go
@@ -3,10 +3,10 @@ package sniff
 import (
 	"bytes"
 	"context"
-	"io"
 	"net/url"
 
-	"github.com/0x2e/fusion/pkg/httpx"
+	"github.com/0x2e/fusion/model"
+	"github.com/0x2e/fusion/service/pull/client"
 	"github.com/mmcdole/gofeed"
 )
 
@@ -44,16 +44,22 @@ func tryWellKnown(ctx context.Context, baseURL string) ([]FeedLink, error) {
 }
 
 func parseRSSUrl(ctx context.Context, url string) (FeedLink, error) {
-	resp, err := httpx.FusionRequest(ctx, url, nil)
+	feedClient := client.NewFeedClient()
+
+	title, err := feedClient.FetchTitle(ctx, url, model.FeedRequestOptions{})
 	if err != nil {
 		return FeedLink{}, err
 	}
-	defer resp.Body.Close()
-	content, err := io.ReadAll(resp.Body)
+
+	declaredLink, err := feedClient.FetchDeclaredLink(ctx, url, model.FeedRequestOptions{})
 	if err != nil {
 		return FeedLink{}, err
 	}
-	return parseRSSContent(content)
+
+	return FeedLink{
+		Title: title,
+		Link:  declaredLink,
+	}, nil
 }
 
 func parseRSSContent(content []byte) (FeedLink, error) {

--- a/service/sniff/wellknown.go
+++ b/service/sniff/wellknown.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"net/url"
 
+	"github.com/mmcdole/gofeed"
+
 	"github.com/0x2e/fusion/model"
 	"github.com/0x2e/fusion/service/pull/client"
-	"github.com/mmcdole/gofeed"
 )
 
 func tryWellKnown(ctx context.Context, baseURL string) ([]FeedLink, error) {


### PR DESCRIPTION
The sniff package uses redundant RSS parsing logic that duplicates logic that's in the service/pull/client package now.

This change adds a FetchDeclaredLink method that exposes functionality that the sniff package needs and switches the sniff.parseRSSUrl to use the client package instead of duplicating RSS parsing functionality.