### PR TITLE
refactor: switch to single bundle strategy

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -15,6 +15,9 @@ const config = {
 			directives: {
 				'script-src': ['self']
 			}
+		},
+		output: {
+			bundleStrategy: 'single'
 		}
 	}
 };


### PR DESCRIPTION
While browsers are able to fetch resources in limited parallel, it can still cause some delays when there are too many files.