### PR TITLE
Switch to more obviously invalid XML

### DIFF
--- a/service/pull/client/client_test.go
+++ b/service/pull/client/client_test.go
@@ -487,11 +487,11 @@ func TestFeedClientFetchItems(t *testing.T) {
 			feedURL:     "https://example.com/feed.xml",
 			options:     model.FeedRequestOptions{},
 			httpRespBody: `<?xml version="1.0" encoding="UTF-8"?>
-<invalid>
-  <malformed>
+<not-a-real-tag>
+  <also-a-fake-tag>
     <content>This is not a valid RSS feed</content>
-  </malformed>
-</invalid>`,
+  </also-a-fake-tag>
+</not-a-real-tag>`,
 			httpStatusCode:     http.StatusOK,
 			httpErrMsg:         "",
 			httpBodyReadErrMsg: "",


### PR DESCRIPTION
Strangely, my LLM coding assistant gets confused and hangs when it encounters the `<invalid>` and `<malformed>` tags in our testcases. This just switches it to more obviously invalid tags that are less likely to trip up LLMs.