### PR TITLE
Unexport httpx.NewClient and httpx.transportOptionFunct

### DIFF
--- a/pkg/httpx/httpx.go
+++ b/pkg/httpx/httpx.go
@@ -5,9 +5,9 @@ import (
 	"time"
 )
 
-type TransportOptionFunc func(transport *http.Transport)
+type transportOptionFunc func(transport *http.Transport)
 
-func NewClient(options ...TransportOptionFunc) *http.Client {
+func newClient(options ...transportOptionFunc) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.DisableKeepAlives = true
 	transport.ForceAttemptHTTP2 = true

--- a/pkg/httpx/request.go
+++ b/pkg/httpx/request.go
@@ -8,7 +8,7 @@ import (
 	"github.com/0x2e/fusion/model"
 )
 
-var globalClient = NewClient()
+var globalClient = newClient()
 
 func FusionRequest(ctx context.Context, link string, options *model.FeedRequestOptions) (*http.Response, error) {
 	client := globalClient
@@ -25,7 +25,7 @@ func FusionRequest(ctx context.Context, link string, options *model.FeedRequestO
 			if err != nil {
 				return nil, err
 			}
-			client = NewClient(func(transport *http.Transport) {
+			client = newClient(func(transport *http.Transport) {
 				transport.Proxy = http.ProxyURL(proxyURL)
 			})
 		}


### PR DESCRIPTION
We don't use these symbols outside of the httpx package, so we should unexport them to reduce the surface area of the package.