### PR TITLE
Change FusionRequest to use a non-pointer type parameter

### DIFF
--- a/pkg/httpx/request.go
+++ b/pkg/httpx/request.go
@@ -10,7 +10,7 @@ import (
 
 var globalClient = NewClient()
 
-func FusionRequest(ctx context.Context, link string, options *model.FeedRequestOptions) (*http.Response, error) {
+func FusionRequest(ctx context.Context, link string, options model.FeedRequestOptions) (*http.Response, error) {
 	client := globalClient
 	req, err := http.NewRequestWithContext(ctx, "GET", link, nil)
 	if err != nil {
@@ -19,16 +19,14 @@ func FusionRequest(ctx context.Context, link string, options *model.FeedRequestO
 	req.Close = true
 	req.Header.Add("User-Agent", "fusion/1.0")
 
-	if options != nil {
-		if options.ReqProxy != nil && *options.ReqProxy != "" {
-			proxyURL, err := url.Parse(*options.ReqProxy)
-			if err != nil {
-				return nil, err
-			}
-			client = NewClient(func(transport *http.Transport) {
-				transport.Proxy = http.ProxyURL(proxyURL)
-			})
+	if options.ReqProxy != nil && *options.ReqProxy != "" {
+		proxyURL, err := url.Parse(*options.ReqProxy)
+		if err != nil {
+			return nil, err
 		}
+		client = NewClient(func(transport *http.Transport) {
+			transport.Proxy = http.ProxyURL(proxyURL)
+		})
 	}
 
 	return client.Do(req)

--- a/service/pull/client/client.go
+++ b/service/pull/client/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/0x2e/fusion/pkg/httpx"
 )
 
-type HttpRequestFn func(ctx context.Context, link string, options *model.FeedRequestOptions) (*http.Response, error)
+type HttpRequestFn func(ctx context.Context, link string, options model.FeedRequestOptions) (*http.Response, error)
 
 // FeedClient retrieves a feed given a feed URL and parses the result.
 type FeedClient struct {
@@ -74,7 +74,7 @@ func (c FeedClient) FetchItems(ctx context.Context, feedURL string, options mode
 }
 
 func (c FeedClient) fetchFeed(ctx context.Context, feedURL string, options model.FeedRequestOptions) (*gofeed.Feed, error) {
-	resp, err := c.httpRequestFn(ctx, feedURL, &options)
+	resp, err := c.httpRequestFn(ctx, feedURL, options)
 	if err != nil {
 		return nil, err
 	}

--- a/service/pull/client/client_test.go
+++ b/service/pull/client/client_test.go
@@ -43,10 +43,10 @@ type mockHTTPClient struct {
 	lastOptions *model.FeedRequestOptions
 }
 
-func (m *mockHTTPClient) Get(ctx context.Context, link string, options *model.FeedRequestOptions) (*http.Response, error) {
+func (m *mockHTTPClient) Get(ctx context.Context, link string, options model.FeedRequestOptions) (*http.Response, error) {
 	// Store the last feed URL and options for assertions.
 	m.lastFeedURL = link
-	m.lastOptions = options
+	m.lastOptions = &options
 
 	if m.err != nil {
 		return nil, m.err

--- a/service/sniff/page.go
+++ b/service/sniff/page.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/0x2e/fusion/model"
 	"github.com/0x2e/fusion/pkg/httpx"
 	"github.com/0x2e/fusion/pkg/logx"
 	"github.com/PuerkitoBio/goquery"
@@ -15,7 +16,7 @@ import (
 func tryPageSource(ctx context.Context, link string) ([]FeedLink, error) {
 	logger := logx.LoggerFromContext(ctx)
 
-	resp, err := httpx.FusionRequest(ctx, link, nil)
+	resp, err := httpx.FusionRequest(ctx, link, model.FeedRequestOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/service/sniff/service.go
+++ b/service/sniff/service.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/0x2e/fusion/model"
 	"github.com/0x2e/fusion/pkg/httpx"
 )
 
@@ -166,7 +167,7 @@ func youtubeMatcher(ctx context.Context, link *url.URL) ([]FeedLink, error) {
 		return nil, nil
 	}
 
-	resp, err := httpx.FusionRequest(ctx, link.String(), nil)
+	resp, err := httpx.FusionRequest(ctx, link.String(), model.FeedRequestOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
FusionRequest currently specifies model.FeedRequestOptions as a pointer rather than as a regular parameter. This is unnecessary, as it's easy for us to treat model.FeedRequestOptions{} as the 'default options' value. With it as a pointer, we clutter our code with extra != nil checks.

This change updates FusionRequest to just take a model.FeedRequestOptions rather than a *model.FeedRequestOptions.