### PR TITLE
Recover after feed fetch failure with exponential backoff

### DIFF
--- a/model/feed.go
+++ b/model/feed.go
@@ -22,19 +22,18 @@ type Feed struct {
 	Link *string `gorm:"link;not null;uniqueIndex:idx_link"`
 	// LastBuild is the last time the content of the feed changed
 	LastBuild *time.Time `gorm:"last_build"`
-	// Failure is the reason of failure. If it is not null or empty, the fetch processor
-	// should skip this feed
-	Failure   *string `gorm:"failure;default:''"`
-	Suspended *bool   `gorm:"suspended;default:false"`
+	// Failure is the error message for the last fetch.
+	Failure *string `gorm:"failure;default:''"`
+	// ConsecutiveFailures is the number of consecutive times we've failed to
+	// retrieve this feed.
+	ConsecutiveFailures uint `gorm:"consecutive_failures;default:0"`
+
+	Suspended *bool `gorm:"suspended;default:false"`
 
 	FeedRequestOptions
 
 	GroupID uint
 	Group   Group
-}
-
-func (f Feed) IsFailed() bool {
-	return f.Failure != nil && *f.Failure != ""
 }
 
 func (f Feed) IsSuspended() bool {

--- a/service/pull/backoff.go
+++ b/service/pull/backoff.go
@@ -21,6 +21,8 @@ func CalculateBackoffTime(consecutiveFailures uint) time.Duration {
 	intervalMinutes := float64(interval.Minutes())
 	backoffMinutes := intervalMinutes * math.Pow(1.8, float64(consecutiveFailures))
 
+	// floats go to Inf if the number is too large to represent in a float type,
+	// so check that it's not +/- Inf.
 	if math.IsInf(backoffMinutes, 0) || backoffMinutes > maxBackoff.Minutes() {
 		return maxBackoff
 	}

--- a/service/pull/backoff.go
+++ b/service/pull/backoff.go
@@ -1,0 +1,29 @@
+package pull
+
+import (
+	"math"
+	"time"
+)
+
+// maxBackoff is the maximum time to wait before checking a feed due to past
+// errors.
+const maxBackoff = 7 * 24 * time.Hour
+
+// CalculateBackoffTime calculates the exponential backoff time based on the
+// number of consecutive failures.
+// The formula is: interval * (1.8 ^ consecutiveFailures), capped at maxBackoff.
+func CalculateBackoffTime(consecutiveFailures uint) time.Duration {
+	// If no failures, no backoff needed
+	if consecutiveFailures == 0 {
+		return 0
+	}
+
+	intervalMinutes := float64(interval.Minutes())
+	backoffMinutes := intervalMinutes * math.Pow(1.8, float64(consecutiveFailures))
+
+	if math.IsInf(backoffMinutes, 0) || backoffMinutes > maxBackoff.Minutes() {
+		return maxBackoff
+	}
+
+	return time.Duration(backoffMinutes) * time.Minute
+}

--- a/service/pull/backoff_test.go
+++ b/service/pull/backoff_test.go
@@ -1,0 +1,55 @@
+package pull_test
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/0x2e/fusion/service/pull"
+)
+
+func TestCalculateBackoffTime(t *testing.T) {
+	for _, tt := range []struct {
+		name                string
+		consecutiveFailures uint
+		expectedBackoff     time.Duration
+	}{
+		{
+			name:                "no failures",
+			consecutiveFailures: 0,
+			expectedBackoff:     0,
+		},
+		{
+			name:                "one failure",
+			consecutiveFailures: 1,
+			expectedBackoff:     54 * time.Minute, // 30 * (1.8^1) = 54 minutes
+		},
+		{
+			name:                "two failures",
+			consecutiveFailures: 2,
+			expectedBackoff:     97 * time.Minute, // 30 * (1.8^2) = 97.2 minutes ≈ 97 minutes
+		},
+		{
+			name:                "three failures",
+			consecutiveFailures: 3,
+			expectedBackoff:     174 * time.Minute, // 30 * (1.8^3) = 174.96 minutes ≈ 174 minutes
+		},
+		{
+			name:                "many failures",
+			consecutiveFailures: 10000,
+			expectedBackoff:     7 * 24 * time.Hour, // Maximum backoff (7 days)
+		},
+		{
+			name:                "maximum failures",
+			consecutiveFailures: math.MaxUint,
+			expectedBackoff:     7 * 24 * time.Hour, // Maximum backoff (7 days)
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			backoff := pull.CalculateBackoffTime(tt.consecutiveFailures)
+			assert.Equal(t, tt.expectedBackoff, backoff)
+		})
+	}
+}

--- a/service/pull/singlefeed.go
+++ b/service/pull/singlefeed.go
@@ -57,14 +57,21 @@ func (r *defaultSingleFeedRepo) InsertItems(items []*model.Item) error {
 
 func (r *defaultSingleFeedRepo) RecordSuccess(lastBuild *time.Time) error {
 	return r.feedRepo.Update(r.feedID, &model.Feed{
-		LastBuild: lastBuild,
-		Failure:   ptr.To(""),
+		LastBuild:           lastBuild,
+		Failure:             ptr.To(""),
+		ConsecutiveFailures: 0,
 	})
 }
 
 func (r *defaultSingleFeedRepo) RecordFailure(readErr error) error {
+	feed, err := r.feedRepo.Get(r.feedID)
+	if err != nil {
+		return err
+	}
+
 	return r.feedRepo.Update(r.feedID, &model.Feed{
-		Failure: ptr.To(readErr.Error()),
+		Failure:             ptr.To(readErr.Error()),
+		ConsecutiveFailures: feed.ConsecutiveFailures + 1,
 	})
 }
 


### PR DESCRIPTION
The current implementation stops attempting to fetch a feed if fusion encounters any error fetching it. The only way to continue fetching the feed is if the user manually forces a refresh.

This allows fusion to recover from feed fetch errors by tracking the number of consecutive failures and slowing down requests for consistent failure. If a feed always fails, we eventually slow to only checking it once per week.

Fixes #67