### PR TITLE
refactor: replace invalidateAll with invalidate for more granular cache control

### DIFF
--- a/frontend/src/lib/components/FeedActionRefresh.svelte
+++ b/frontend/src/lib/components/FeedActionRefresh.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { invalidateAll } from '$app/navigation';
 	import { refreshFeeds } from '$lib/api/feed';
 	import type { Feed } from '$lib/api/model';
 	import { t } from '$lib/i18n';
@@ -21,14 +20,12 @@
 		}
 		toast.promise(refreshFeeds({ id: feed?.id, all: all }), {
 			success: () => {
-				invalidateAll();
 				if (all) {
 					return t('feed.refresh.all.run_in_background');
 				}
 				return t('state.success');
 			},
 			error: (e) => {
-				invalidateAll();
 				console.log(e);
 				return String(e);
 			}

--- a/frontend/src/lib/components/ItemActionBookmark.svelte
+++ b/frontend/src/lib/components/ItemActionBookmark.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { invalidateAll } from '$app/navigation';
+	import { invalidate } from '$app/navigation';
+	import { page } from '$app/state';
 	import { updateBookmark } from '$lib/api/item';
 	import type { Item } from '$lib/api/model';
 	import { t } from '$lib/i18n';
@@ -16,7 +17,7 @@
 		e.preventDefault();
 		try {
 			await updateBookmark(data.id, !data.bookmark);
-			invalidateAll();
+			invalidate('page:' + page.url.pathname);
 		} catch (e) {
 			toast.error((e as Error).message);
 		}

--- a/frontend/src/lib/components/ItemActionMarkAllasRead.svelte
+++ b/frontend/src/lib/components/ItemActionMarkAllasRead.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { invalidateAll } from '$app/navigation';
+	import { invalidate } from '$app/navigation';
+	import { page } from '$app/state';
 	import { updateUnread } from '$lib/api/item';
 	import type { Item } from '$lib/api/model';
 	import { t } from '$lib/i18n';
@@ -27,7 +28,7 @@
 			const ids = props.items.map((v) => v.id);
 			await updateUnread(ids, false);
 			toast.success(t('state.success'));
-			invalidateAll();
+			invalidate('page:' + page.url.pathname);
 		} catch (e) {
 			toast.error((e as Error).message);
 		}

--- a/frontend/src/lib/components/ItemActionUnread.svelte
+++ b/frontend/src/lib/components/ItemActionUnread.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { invalidateAll } from '$app/navigation';
+	import { invalidate } from '$app/navigation';
+	import { page } from '$app/state';
 	import { updateUnread } from '$lib/api/item';
 	import type { Item } from '$lib/api/model';
 	import { t } from '$lib/i18n';
@@ -16,7 +17,7 @@
 		e.preventDefault();
 		try {
 			await updateUnread([data.id], !data.unread);
-			invalidateAll();
+			invalidate('page:' + page.url.pathname);
 		} catch (e) {
 			toast.error((e as Error).message);
 		}

--- a/frontend/src/lib/components/ItemList.svelte
+++ b/frontend/src/lib/components/ItemList.svelte
@@ -39,7 +39,7 @@
 		filter.page = pageNumber;
 		const url = page.url;
 		applyFilterToURL(url, filter);
-		await goto(url, { invalidateAll: true });
+		await goto(url, { invalidate: ['page:' + page.url.pathname] });
 	}
 </script>
 

--- a/frontend/src/routes/(authed)/+page.ts
+++ b/frontend/src/routes/(authed)/+page.ts
@@ -2,7 +2,9 @@ import { listItems, parseURLtoFilter } from '$lib/api/item';
 import { fullItemFilter } from '$lib/state.svelte';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ url }) => {
+export const load: PageLoad = async ({ depends, url }) => {
+	depends(`page:${url.pathname}`);
+
 	const filter = parseURLtoFilter(url.searchParams, {
 		unread: true,
 		bookmark: undefined

--- a/frontend/src/routes/(authed)/all/+page.ts
+++ b/frontend/src/routes/(authed)/all/+page.ts
@@ -2,7 +2,9 @@ import { listItems, parseURLtoFilter } from '$lib/api/item';
 import { fullItemFilter } from '$lib/state.svelte';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ url }) => {
+export const load: PageLoad = async ({ url, depends }) => {
+	depends(`page:${url.pathname}`);
+
 	const filter = parseURLtoFilter(url.searchParams, {
 		unread: undefined,
 		bookmark: undefined

--- a/frontend/src/routes/(authed)/bookmarks/+page.ts
+++ b/frontend/src/routes/(authed)/bookmarks/+page.ts
@@ -2,7 +2,9 @@ import { listItems, parseURLtoFilter } from '$lib/api/item';
 import { fullItemFilter } from '$lib/state.svelte';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ url }) => {
+export const load: PageLoad = async ({ url, depends }) => {
+	depends(`page:${url.pathname}`);
+
 	const filter = parseURLtoFilter(url.searchParams, {
 		unread: undefined,
 		bookmark: true

--- a/frontend/src/routes/(authed)/feeds/[id]/+page.ts
+++ b/frontend/src/routes/(authed)/feeds/[id]/+page.ts
@@ -5,7 +5,9 @@ import type { PageLoad } from './$types';
 
 export const prerender = false;
 
-export const load: PageLoad = async ({ url, params }) => {
+export const load: PageLoad = async ({ depends, url, params }) => {
+	depends(`page:${url.pathname}`);
+
 	const id = parseInt(params.id);
 	const feed = getFeed(id);
 	const filter = parseURLtoFilter(url.searchParams, {

--- a/frontend/src/routes/(authed)/feeds/[id]/ActionMenu.svelte
+++ b/frontend/src/routes/(authed)/feeds/[id]/ActionMenu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { goto, invalidateAll } from '$app/navigation';
+	import { goto, invalidate, invalidateAll } from '$app/navigation';
+	import { page } from '$app/state';
 	import { deleteFeed, updateFeed, type FeedUpdateForm } from '$lib/api/feed';
 	import type { Feed } from '$lib/api/model';
 	import { t } from '$lib/i18n';
@@ -32,10 +33,10 @@
 				suspended: !feed.suspended
 			});
 			toast.success(t('state.success'));
+			invalidate('page:' + page.url.pathname);
 		} catch (e) {
 			toast.error((e as Error).message);
 		}
-		invalidateAll();
 	}
 
 	async function handleDelete() {
@@ -47,7 +48,6 @@
 		} catch (e) {
 			toast.error((e as Error).message);
 		}
-		invalidateAll();
 	}
 
 	async function handleUpdate(e: Event) {
@@ -55,12 +55,11 @@
 		toast.promise(updateFeed(feed.id, settingsForm), {
 			loading: 'Updating',
 			success: () => {
-				invalidateAll();
+				invalidate('page:' + page.url.pathname);
 				settingsModal?.close();
 				return t('state.success');
 			},
 			error: (e) => {
-				invalidateAll();
 				return (e as Error).message;
 			}
 		});

--- a/frontend/src/routes/(authed)/items/[id]/+page.ts
+++ b/frontend/src/routes/(authed)/items/[id]/+page.ts
@@ -4,7 +4,9 @@ import type { PageLoad } from './$types';
 
 export const prerender = false;
 
-export const load: PageLoad = ({ params }) => {
+export const load: PageLoad = ({ depends, url, params }) => {
+	depends(`page:${url.pathname}`);
+
 	const id = parseInt(params.id);
 	if (id < 1) {
 		error(404, 'wrong id');

--- a/frontend/src/routes/(authed)/items/[id]/ItemSwitcher.svelte
+++ b/frontend/src/routes/(authed)/items/[id]/ItemSwitcher.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { listItems } from '$lib/api/item';
 	import type { Item } from '$lib/api/model';
 	import { defaultPageSize } from '$lib/consts';
@@ -76,7 +77,9 @@
 			currentItemIndex = indexBackup;
 			return;
 		}
-		goto('/items/' + next.id, { invalidateAll: true });
+		goto('/items/' + next.id, {
+			invalidate: ['page:' + page.url.pathname]
+		});
 	}
 </script>
 

--- a/frontend/src/routes/(authed)/search/+page.svelte
+++ b/frontend/src/routes/(authed)/search/+page.svelte
@@ -18,7 +18,7 @@
 		applyFilterToURL(url, filterForm);
 		console.log(url.toString());
 		goto(url, {
-			invalidate: ['page:search']
+			invalidate: ['page:' + page.url.pathname]
 		});
 	}
 </script>

--- a/frontend/src/routes/(authed)/search/+page.ts
+++ b/frontend/src/routes/(authed)/search/+page.ts
@@ -3,7 +3,7 @@ import { fullItemFilter } from '$lib/state.svelte';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ url, depends }) => {
-	depends('page:search');
+	depends(`page:${url.pathname}`);
 
 	const filter = parseURLtoFilter(url.searchParams);
 	Object.assign(fullItemFilter, filter);


### PR DESCRIPTION
Didn't find an easy way to invalidate the load function of the `current` page, so use `page:{pathname}` as the key.