### PR TITLE
Handle feeds that use relative paths for links

### DIFF
--- a/service/pull/client/client.go
+++ b/service/pull/client/client.go
@@ -69,7 +69,7 @@ func (c FeedClient) FetchItems(ctx context.Context, feedURL string, options mode
 
 	return FetchItemsResult{
 		LastBuild: feed.UpdatedParsed,
-		Items:     ParseGoFeedItems(feed.Items),
+		Items:     ParseGoFeedItems(feedURL, feed.Items),
 	}, nil
 }
 

--- a/service/pull/client/parse.go
+++ b/service/pull/client/parse.go
@@ -1,12 +1,16 @@
 package client
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/0x2e/fusion/model"
+	"github.com/0x2e/fusion/pkg/ptr"
 
 	"github.com/mmcdole/gofeed"
 )
 
-func ParseGoFeedItems(gfItems []*gofeed.Item) []*model.Item {
+func ParseGoFeedItems(feedURL string, gfItems []*gofeed.Item) []*model.Item {
 	items := make([]*model.Item, 0, len(gfItems))
 	for _, item := range gfItems {
 		if item == nil {
@@ -25,7 +29,7 @@ func ParseGoFeedItems(gfItems []*gofeed.Item) []*model.Item {
 		items = append(items, &model.Item{
 			Title:   &item.Title,
 			GUID:    &guid,
-			Link:    &item.Link,
+			Link:    ptr.To(parseLink(feedURL, item.Link)),
 			Content: &content,
 			PubDate: item.PublishedParsed,
 			Unread:  &unread,
@@ -33,4 +37,27 @@ func ParseGoFeedItems(gfItems []*gofeed.Item) []*model.Item {
 	}
 
 	return items
+}
+
+func parseLink(feedURL string, linkURL string) string {
+	// If the link URL is not a relative path, treat it as a full URL.
+	if !strings.HasPrefix(linkURL, "/") {
+		return linkURL
+	}
+
+	baseURL, err := url.Parse(feedURL)
+	// If we can't parse the feed URL, we can't repair a relative path, so just
+	// return whatever is in the link URL.
+	if err != nil {
+		return linkURL
+	}
+
+	// Reduce the feed URL to just the scheme and hostname.
+	base := url.URL{
+		Scheme: baseURL.Scheme,
+		Host:   baseURL.Host,
+	}
+
+	// Combine the feed base URL with the relative path to create a full URL.
+	return base.String() + linkURL
 }

--- a/service/pull/client/parse.go
+++ b/service/pull/client/parse.go
@@ -52,12 +52,13 @@ func parseLink(feedURL string, linkURL string) string {
 		return linkURL
 	}
 
-	// Reduce the feed URL to just the scheme and hostname.
-	base := url.URL{
-		Scheme: baseURL.Scheme,
-		Host:   baseURL.Host,
+	pathURL, err := url.Parse(linkURL)
+	// If we can't parse the link URL, we can't repair a relative path, so just
+	// return whatever is in the link URL.
+	if err != nil {
+		return linkURL
 	}
 
 	// Combine the feed base URL with the relative path to create a full URL.
-	return base.String() + linkURL
+	return baseURL.ResolveReference(pathURL).String()
 }

--- a/service/pull/client/parse_test.go
+++ b/service/pull/client/parse_test.go
@@ -14,11 +14,13 @@ import (
 func TestParseGoFeedItems(t *testing.T) {
 	for _, tt := range []struct {
 		description string
+		feedURL     string
 		gfItems     []*gofeed.Item
 		expected    []*model.Item
 	}{
 		{
 			description: "converts gofeed items to model items with complete data",
+			feedURL:     "https://example.com/feed",
 			gfItems: []*gofeed.Item{
 				{
 					Title:           "Test Item",
@@ -41,7 +43,32 @@ func TestParseGoFeedItems(t *testing.T) {
 			},
 		},
 		{
+			description: "converts relative path links to full URLs",
+			feedURL:     "https://example.com/feed",
+			gfItems: []*gofeed.Item{
+				{
+					Title:           "Test Item with Relative Path",
+					Link:            "/link",
+					GUID:            "guid",
+					Content:         "<p>This is the content</p>",
+					Description:     "This is the description",
+					PublishedParsed: mustParseTime("2025-01-01T12:00:00Z"),
+				},
+			},
+			expected: []*model.Item{
+				{
+					Title:   ptr.To("Test Item with Relative Path"),
+					Link:    ptr.To("https://example.com/link"),
+					GUID:    ptr.To("guid"),
+					Content: ptr.To("<p>This is the content</p>"),
+					PubDate: mustParseTime("2025-01-01T12:00:00Z"),
+					Unread:  ptr.To(true),
+				},
+			},
+		},
+		{
 			description: "uses description when content is empty",
+			feedURL:     "https://example.com/feed",
 			gfItems: []*gofeed.Item{
 				{
 					Title:           "Test Item",
@@ -65,6 +92,7 @@ func TestParseGoFeedItems(t *testing.T) {
 		},
 		{
 			description: "uses link when GUID is empty",
+			feedURL:     "https://example.com/feed",
 			gfItems: []*gofeed.Item{
 				{
 					Title:           "Test Item",
@@ -88,6 +116,7 @@ func TestParseGoFeedItems(t *testing.T) {
 		},
 		{
 			description: "handles both empty content and empty GUID",
+			feedURL:     "https://example.com/feed",
 			gfItems: []*gofeed.Item{
 				{
 					Title:           "Test Item",
@@ -111,6 +140,7 @@ func TestParseGoFeedItems(t *testing.T) {
 		},
 		{
 			description: "handles multiple items",
+			feedURL:     "https://example.com/feed",
 			gfItems: []*gofeed.Item{
 				{
 					Title:           "Item 1",
@@ -150,11 +180,13 @@ func TestParseGoFeedItems(t *testing.T) {
 		},
 		{
 			description: "returns empty slice for empty input",
+			feedURL:     "https://example.com/feed",
 			gfItems:     []*gofeed.Item{},
 			expected:    []*model.Item{},
 		},
 		{
 			description: "skips nil items in the array",
+			feedURL:     "https://example.com/feed",
 			gfItems: []*gofeed.Item{
 				{
 					Title:           "Valid Item",
@@ -193,7 +225,7 @@ func TestParseGoFeedItems(t *testing.T) {
 		},
 	} {
 		t.Run(tt.description, func(t *testing.T) {
-			result := client.ParseGoFeedItems(tt.gfItems)
+			result := client.ParseGoFeedItems(tt.feedURL, tt.gfItems)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
Some feeds use relative paths for the link field (e.g., "/item1" rather than "https://example.com/item1").

fusion's current behavior is to preserve the relative paths, but then when the user tries to click a link on one of these feeds, it sends the user to a non-existent path within fusion.

This fixes the interpretation of relative path links so that we automatically convert them back to absolute path URLs based on the feed URL.

Fixes #94