### PR TITLE
Only pull feed once per polling interval

### DIFF
--- a/service/pull/pull.go
+++ b/service/pull/pull.go
@@ -3,7 +3,6 @@ package pull
 import (
 	"context"
 	"errors"
-	"net"
 	"sync"
 	"time"
 
@@ -80,17 +79,9 @@ func (p *Puller) PullAll(ctx context.Context, force bool) error {
 				<-routinePool
 			}()
 
-			logger := logger.With("feed_id", f.ID)
 			if err := p.do(ctx, f, force); err != nil {
+				logger := logger.With("feed_id", f.ID)
 				logger.Errorln(err)
-				if _, ok := err.(net.Error); ok {
-					for i := 1; i < 4; i++ {
-						logger.Infof("%dth retry", i)
-						if p.do(ctx, f, true) == nil {
-							break
-						}
-					}
-				}
 			}
 		}(f)
 	}


### PR DESCRIPTION
fusion's previous behavior was to immediately retry requesting a feed when the request fails. This made more sense before we added failure recovery (df412f17d3fbb297d5a3753afa813d23d25731a3).

Now, immediately retrying on failure complicates the implementation and risks getting the client banned if the server is responding with HTTP 429 errors and we just keep spamming the same requests.

This change adjusts the polling behavior so that we only request each feed once per polling interval. If the request fails, we'll try again at the next polling interval.