### PR TITLE
ci: Publish container image to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,13 +15,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # for vite extracting git tag/hash
+      - name: Lowercase Owner and Repository Name
+        run: echo "REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
             rook1e404/fusion
-            ghcr.io/${{ github.repository }}
+            ghcr.io/${{ env.REPOSITORY }}
           tags: |
             type=semver,pattern={{version}}
       - name: Set up QEMU

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -18,6 +21,7 @@ jobs:
         with:
           images: |
             rook1e404/fusion
+            ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
       - name: Set up QEMU
@@ -29,6 +33,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
> [!IMPORTANT]
> You might need to make the container public once it's pushed to the registry. You should be able to do that [here](https://github.com/0x2E?tab=packages).

In addition to Dockerhub, images will also be published to GHCR. I also bumped the build push action to v6
Fixes: #135

