### PR TITLE
Allow to shuffle items

### DIFF
--- a/frontend/src/lib/api/item.ts
+++ b/frontend/src/lib/api/item.ts
@@ -11,6 +11,8 @@ export type ListFilter = {
 	group_id?: number;
 	unread?: boolean;
 	bookmark?: boolean;
+	shuffle?: boolean;
+	seed?: number;
 };
 
 export async function listItems(options?: ListFilter) {

--- a/frontend/src/lib/i18n/langs/de.ts
+++ b/frontend/src/lib/i18n/langs/de.ts
@@ -87,6 +87,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': 'Alle Feeds aktualisieren',
 	'settings.global_actions.export_all_feeds': 'Alle Feeds exportieren',
 
+	'settings.groups.shuffle': 'Artikel in Gruppen zufällig anordnen',
 	'settings.groups.description': 'Der Gruppenname sollte eindeutig sein.',
 	'settings.groups.delete.confirm':
 		'Sind Sie sicher, dass Sie diese Gruppe löschen möchten? Alle ihre Feeds werden in die Standardgruppe verschoben',

--- a/frontend/src/lib/i18n/langs/en.ts
+++ b/frontend/src/lib/i18n/langs/en.ts
@@ -87,6 +87,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': 'Refresh all feeds',
 	'settings.global_actions.export_all_feeds': 'Export all feeds',
 
+	'settings.groups.shuffle': 'Randomize articles within groups',
 	'settings.groups.description': "Group's name should be unique.",
 	'settings.groups.delete.confirm':
 		'Are you sure you want to delete this group? All its feeds will be moved to the default group',

--- a/frontend/src/lib/i18n/langs/es.ts
+++ b/frontend/src/lib/i18n/langs/es.ts
@@ -88,6 +88,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': 'Actualizar todos los feeds',
 	'settings.global_actions.export_all_feeds': 'Exportar todos los feeds',
 
+	'settings.groups.shuffle': 'Aleatorizar artículos dentro de los grupos',
 	'settings.groups.description': 'El nombre del grupo debe ser único.',
 	'settings.groups.delete.confirm':
 		'¿Estás seguro de que quieres eliminar este grupo? Todos sus feeds se moverán al grupo predeterminado',

--- a/frontend/src/lib/i18n/langs/fr.ts
+++ b/frontend/src/lib/i18n/langs/fr.ts
@@ -87,6 +87,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': 'Actualiser tous les flux',
 	'settings.global_actions.export_all_feeds': 'Exporter tous les flux',
 
+	'settings.groups.shuffle': 'Randomiser les éléments au sein des groupes',
 	'settings.groups.description': 'Le nom du groupe doit être unique.',
 	'settings.groups.delete.confirm':
 		'Êtes-vous sûr de vouloir supprimer ce groupe? Tous ses flux seront déplacés vers le groupe par défaut',

--- a/frontend/src/lib/i18n/langs/pt-BR.ts
+++ b/frontend/src/lib/i18n/langs/pt-BR.ts
@@ -88,6 +88,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': 'Atualizar todos os feeds',
 	'settings.global_actions.export_all_feeds': 'Exportar todos os feeds',
 
+	'settings.groups.shuffle': 'Randomizar artigos dentro de grupos',
 	'settings.groups.description': 'O nome do grupo deve ser único.',
 	'settings.groups.delete.confirm':
 		'Tem certeza que deseja excluir este grupo? Todos os seus feeds serão movidos para o grupo padrão',

--- a/frontend/src/lib/i18n/langs/pt.ts
+++ b/frontend/src/lib/i18n/langs/pt.ts
@@ -87,6 +87,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': 'Atualizar todos os feeds',
 	'settings.global_actions.export_all_feeds': 'Exportar todos os feeds',
 
+	'settings.groups.shuffle': 'Randomizar artigos dentro de grupos',
 	'settings.groups.description': 'O nome do grupo deve ser único.',
 	'settings.groups.delete.confirm':
 		'Tem a certeza que pretende eliminar este grupo? Todos os seus feeds serão movidos para o grupo predefinido',

--- a/frontend/src/lib/i18n/langs/ru.ts
+++ b/frontend/src/lib/i18n/langs/ru.ts
@@ -87,6 +87,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': 'Обновить все ленты',
 	'settings.global_actions.export_all_feeds': 'Экспортировать все ленты',
 
+	'settings.groups.shuffle': 'Перемешать статьи внутри групп',
 	'settings.groups.description': 'Имя группы должно быть уникальным.',
 	'settings.groups.delete.confirm':
 		'Вы уверены, что хотите удалить эту группу? Все ее ленты будут перемещены в группу по умолчанию',

--- a/frontend/src/lib/i18n/langs/sv.ts
+++ b/frontend/src/lib/i18n/langs/sv.ts
@@ -86,6 +86,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': 'Uppdatera alla flöden',
 	'settings.global_actions.export_all_feeds': 'Exportera alla flöden',
 
+	'settings.groups.shuffle': 'Slumpmässigt sortera artiklar inom grupper',
 	'settings.groups.description': 'Gruppens namn måste vara unikt.',
 	'settings.groups.delete.confirm':
 		'Är du säker på att du vill ta bort denna grupp? Alla dess flöden kommer att flyttas till standardgruppen',

--- a/frontend/src/lib/i18n/langs/zh-Hans.ts
+++ b/frontend/src/lib/i18n/langs/zh-Hans.ts
@@ -85,6 +85,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': '刷新所有订阅源',
 	'settings.global_actions.export_all_feeds': '导出所有订阅源',
 
+	'settings.groups.shuffle': '随机化组内的文章',
 	'settings.groups.description': '分组名称必须唯一。',
 	'settings.groups.delete.confirm': '确定要删除此分组吗？其中的所有订阅源将被移至默认分组',
 	'settings.groups.delete.error.delete_the_default': '无法删除默认分组',

--- a/frontend/src/lib/i18n/langs/zh-Hant.ts
+++ b/frontend/src/lib/i18n/langs/zh-Hant.ts
@@ -84,6 +84,7 @@ const lang = {
 	'settings.global_actions.refresh_all_feeds': '重新整理所有訂閱源',
 	'settings.global_actions.export_all_feeds': '匯出所有訂閱源',
 
+	'settings.groups.shuffle': '隨機化組內的文章',
 	'settings.groups.description': '群組名稱必須是唯一的。',
 	'settings.groups.delete.confirm': '您確定要刪除此群組嗎？所有訂閱源將被移動到預設群組',
 	'settings.groups.delete.error.delete_the_default': '無法刪除預設群組',

--- a/frontend/src/routes/(authed)/groups/[id]/+page.ts
+++ b/frontend/src/routes/(authed)/groups/[id]/+page.ts
@@ -22,6 +22,14 @@ export const load: PageLoad = async ({ url, params, depends }) => {
 		feed_id: undefined,
 		group_id: id
 	});
+
+	const shuffle = localStorage.getItem("shuffleArticles") === 'true';
+	const seedString = localStorage.getItem("shuffleSeed")
+	const seed = seedString !== null ? parseInt(seedString, 10) : undefined;
+	if (shuffle === true) {
+		filter.shuffle = true;
+		filter.seed = seed;
+	}
 	const items = listItems(filter);
 	return { group, items: items };
 };

--- a/frontend/src/routes/(authed)/settings/GroupSection.svelte
+++ b/frontend/src/routes/(authed)/settings/GroupSection.svelte
@@ -7,6 +7,8 @@
 	import { t } from '$lib/i18n';
 
 	let newGroup = $state('');
+	let shuffleArticles = $state(localStorage.getItem("shuffleArticles") === 'true');
+	let shuffleSeed = $state(parseInt(localStorage.getItem("shuffleSeed")));
 	const existingGroups = $derived(globalState.groups);
 
 	async function handleAddNew() {
@@ -45,10 +47,22 @@
 		}
 		invalidateAll();
 	}
+	async function handleShuffle(){
+		shuffleArticles = !shuffleArticles;
+		localStorage.setItem("shuffleArticles" , shuffleArticles);
+		localStorage.setItem("shuffleSeed", Math.floor(new Date().getTime() / 1000))
+	}
 </script>
 
 <Section id="groups" title={t('common.groups')} description={t('settings.groups.description')}>
 	<div class="flex flex-col space-y-4">
+		<div class="flex flex-col items-center space-x-2 md:flex-row">
+		<label class="inline-flex items-center cursor-pointer">
+			<input type="checkbox"  class="sr-only peer" onclick={handleShuffle} checked={shuffleArticles}>
+			<div class="relative w-11 h-6 bg-base-300 rounded-full peer after:rounded-full after:bg-white after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:border-gray-300 after:border after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600 dark:peer-checked:bg-blue-600"></div>
+			<span class="ms-3 text-sm font-medium text">{t('settings.groups.shuffle')}</span>
+		</label>
+		</div>
 		{#each existingGroups as g}
 			<div class="flex flex-col items-center space-x-2 md:flex-row">
 				<input type="text" class="input w-full md:w-56" bind:value={g.name} />

--- a/server/item.go
+++ b/server/item.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"math/rand"
 
 	"github.com/0x2e/fusion/model"
 	"github.com/0x2e/fusion/repo"
@@ -40,6 +41,13 @@ func (i Item) List(ctx context.Context, req *ReqItemList) (*RespItemList, error)
 		req.PageSize = 10
 	}
 	data, total, err := i.repo.List(filter, req.Page, req.PageSize)
+	if req.Shuffle != nil && req.Seed != nil && *req.Shuffle {
+		r := rand.New(rand.NewSource(*req.Seed))
+		r.Shuffle(
+			len(data),
+			func(i, j int) { data[i], data[j] = data[j], data[i] },
+		)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/server/item_form.go
+++ b/server/item_form.go
@@ -28,6 +28,8 @@ type ReqItemList struct {
 	GroupID  *uint   `query:"group_id"`
 	Unread   *bool   `query:"unread"`
 	Bookmark *bool   `query:"bookmark"`
+	Shuffle  *bool   `query:"shuffle"`
+	Seed     *int64  `query:"seed"`
 }
 
 type RespItemList struct {


### PR DESCRIPTION
## Hello @0x2E 

I really like the software you've built and i want to contribute to it.

I found myself struggling with looking onto group page then more than one feed with lot of entries attached to it, because the page was starting to look boring and uninformative. I thought i can find any setting in settings menu which will allow me to shuffle entries to make my feed more informative, but this feature was not implemented. I took on this opportunity and implement it myself.

## How it looks like
![image](https://github.com/user-attachments/assets/90d54740-f7cb-4fa2-a5f6-ef8d7663eb20)
![image](https://github.com/user-attachments/assets/193a29c7-6127-4ab4-b2c4-665fcbbe971f)

## Behavior
Then the toggler ste is on all the items on group feed will be shuffled. `shuffleArticles` and `shuffleSeed` variables now will be stored in `localStorage` but as i can see in #167 issue you want to create new `settings` endpoint on server.I think that it will be very simple to migrate my approach to new persistent settings because `localStorage.setItem()` can be easily swapped to post request on new endpoint . 

Also i am thinking about adding expiration time to `shuffleSeed`, to reshuffle items after some time. This date can be hardcoded or can be provided by new setting. What do you think about it?