### PR TITLE
add share action for items.

### DIFF
--- a/frontend/src/lib/components/ItemActionShareLink.svelte
+++ b/frontend/src/lib/components/ItemActionShareLink.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import type { Item } from '$lib/api/model';
+	import { t } from '$lib/i18n';
+	import { Share2 } from 'lucide-svelte';
+	import { activateShortcut, deactivateShortcut, shortcuts } from './ShortcutHelpModal.svelte';
+	import { toast } from 'svelte-sonner';
+
+	interface Props {
+		item: Item;
+		enableShortcut?: boolean;
+	}
+
+	let { item, enableShortcut }: Props = $props();
+
+	// only show button if native share is available
+	const isShareSupported = !!navigator?.share;
+
+	let el = $state<HTMLElement>();
+	$effect(() => {
+		if (!el) return;
+
+		if (enableShortcut) {
+			activateShortcut(el, shortcuts.shareItem.keys);
+		} else {
+			deactivateShortcut(el);
+		}
+	});
+
+	function shareItem() {
+		try {
+			navigator.share({
+				title: item.title,
+				url: item.link
+			});
+		} catch (e) {
+			toast.error((e as Error).message);
+		}
+	}
+</script>
+
+{#if isShareSupported}
+	<div class="tooltip tooltip-bottom" data-tip={t('item.share')}>
+		<button bind:this={el} class="btn btn-ghost btn-square" onclick={shareItem}>
+			<Share2 class="size-4" />
+		</button>
+	</div>
+{/if}

--- a/frontend/src/lib/components/ItemActionShareLink.svelte
+++ b/frontend/src/lib/components/ItemActionShareLink.svelte
@@ -2,29 +2,16 @@
 	import type { Item } from '$lib/api/model';
 	import { t } from '$lib/i18n';
 	import { Share2 } from 'lucide-svelte';
-	import { activateShortcut, deactivateShortcut, shortcuts } from './ShortcutHelpModal.svelte';
 	import { toast } from 'svelte-sonner';
 
 	interface Props {
 		item: Item;
-		enableShortcut?: boolean;
 	}
 
-	let { item, enableShortcut }: Props = $props();
+	let { item }: Props = $props();
 
 	// only show button if native share is available
 	const isShareSupported = !!navigator?.share;
-
-	let el = $state<HTMLElement>();
-	$effect(() => {
-		if (!el) return;
-
-		if (enableShortcut) {
-			activateShortcut(el, shortcuts.shareItem.keys);
-		} else {
-			deactivateShortcut(el);
-		}
-	});
 
 	function shareItem() {
 		try {
@@ -40,7 +27,7 @@
 
 {#if isShareSupported}
 	<div class="tooltip tooltip-bottom" data-tip={t('item.share')}>
-		<button bind:this={el} class="btn btn-ghost btn-square" onclick={shareItem}>
+		<button class="btn btn-ghost btn-square" onclick={shareItem}>
 			<Share2 class="size-4" />
 		</button>
 	</div>

--- a/frontend/src/lib/components/ShortcutHelpModal.svelte
+++ b/frontend/src/lib/components/ShortcutHelpModal.svelte
@@ -18,7 +18,6 @@
 		},
 		toggleBookmark: { keys: 'b', desc: t('shortcuts.toggle_bookmark') },
 		viewOriginal: { keys: 'v', desc: t('shortcuts.view_original') },
-		shareItem: { keys: 's', desc: t('shortcuts.share') },
 		nextFeed: { keys: 'Shift+J', desc: t('shortcuts.next_feed') },
 		prevFeed: { keys: 'Shift+K', desc: t('shortcuts.prev_feed') },
 		openSelected: { keys: 'Enter', desc: t('shortcuts.open_selected') },

--- a/frontend/src/lib/components/ShortcutHelpModal.svelte
+++ b/frontend/src/lib/components/ShortcutHelpModal.svelte
@@ -18,6 +18,7 @@
 		},
 		toggleBookmark: { keys: 'b', desc: t('shortcuts.toggle_bookmark') },
 		viewOriginal: { keys: 'v', desc: t('shortcuts.view_original') },
+		shareItem: { keys: 's', desc: t('shortcuts.share') },
 		nextFeed: { keys: 'Shift+J', desc: t('shortcuts.next_feed') },
 		prevFeed: { keys: 'Shift+K', desc: t('shortcuts.prev_feed') },
 		openSelected: { keys: 'Enter', desc: t('shortcuts.open_selected') },

--- a/frontend/src/lib/i18n/langs/ca.ts
+++ b/frontend/src/lib/i18n/langs/ca.ts
@@ -70,6 +70,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Treure dels marcadors',
 	'item.goto_feed': 'Anar al canal',
 	'item.visit_the_original': "Visitar l'enllaç original",
+	'item.share': 'Compatir',
 
 	// settings
 	'settings.appearance': 'Aparença',

--- a/frontend/src/lib/i18n/langs/de.ts
+++ b/frontend/src/lib/i18n/langs/de.ts
@@ -77,6 +77,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Aus Lesezeichen entfernen',
 	'item.goto_feed': 'Zum Feed gehen',
 	'item.visit_the_original': 'Originallink besuchen',
+	'item.share': 'Teilen',
 
 	// settings
 	'settings.appearance': 'Erscheinungsbild',
@@ -104,6 +105,7 @@ const lang = {
 	'shortcuts.toggle_unread': 'Gelesen/Ungelesen umschalten',
 	'shortcuts.toggle_bookmark': 'Lesezeichen umschalten',
 	'shortcuts.view_original': 'Originallink ansehen',
+	'shortcuts.share': 'Teilen',
 	'shortcuts.next_feed': 'Nächster Feed',
 	'shortcuts.prev_feed': 'Vorheriger Feed',
 	'shortcuts.open_selected': 'Auswahl öffnen',

--- a/frontend/src/lib/i18n/langs/en.ts
+++ b/frontend/src/lib/i18n/langs/en.ts
@@ -77,6 +77,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Remove from bookmark',
 	'item.goto_feed': 'Go to feed',
 	'item.visit_the_original': 'Visit original link',
+	'item.share': 'Share',
 
 	// settings
 	'settings.appearance': 'Appearance',
@@ -103,6 +104,7 @@ const lang = {
 	'shortcuts.toggle_unread': 'Toggle read/unread',
 	'shortcuts.toggle_bookmark': 'Toggle bookmark',
 	'shortcuts.view_original': 'View original',
+	'shortcuts.share': 'Share',
 	'shortcuts.next_feed': 'Next feed',
 	'shortcuts.prev_feed': 'Previous feed',
 	'shortcuts.open_selected': 'Open selection',

--- a/frontend/src/lib/i18n/langs/es.ts
+++ b/frontend/src/lib/i18n/langs/es.ts
@@ -78,6 +78,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Eliminar de marcadores',
 	'item.goto_feed': 'Ir al feed',
 	'item.visit_the_original': 'Visitar enlace original',
+	'item.share': 'Compartir',
 
 	// settings
 	'settings.appearance': 'Apariencia',

--- a/frontend/src/lib/i18n/langs/fr.ts
+++ b/frontend/src/lib/i18n/langs/fr.ts
@@ -77,6 +77,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Retirer des favoris',
 	'item.goto_feed': 'Aller au flux',
 	'item.visit_the_original': 'Visiter le lien original',
+	'item.share': 'Partager',
 
 	// settings
 	'settings.appearance': 'Apparence',

--- a/frontend/src/lib/i18n/langs/pl.ts
+++ b/frontend/src/lib/i18n/langs/pl.ts
@@ -78,6 +78,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Usuń z zakładek',
 	'item.goto_feed': 'Idź do kanału',
 	'item.visit_the_original': 'Odwiedź link źródłowy',
+	'item.share': 'Udostępnij',
 
 	// settings
 	'settings.appearance': 'Wygląd',

--- a/frontend/src/lib/i18n/langs/pt-BR.ts
+++ b/frontend/src/lib/i18n/langs/pt-BR.ts
@@ -78,6 +78,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Remover dos favoritos',
 	'item.goto_feed': 'Ir para o feed',
 	'item.visit_the_original': 'Visitar link original',
+	'item.share': 'Compartilhar',
 
 	// settings
 	'settings.appearance': 'Aparência',

--- a/frontend/src/lib/i18n/langs/pt.ts
+++ b/frontend/src/lib/i18n/langs/pt.ts
@@ -77,6 +77,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Remover dos favoritos',
 	'item.goto_feed': 'Ir para o feed',
 	'item.visit_the_original': 'Visitar link original',
+	'item.share': 'Partilhar',
 
 	// settings
 	'settings.appearance': 'Aparência',

--- a/frontend/src/lib/i18n/langs/ru.ts
+++ b/frontend/src/lib/i18n/langs/ru.ts
@@ -77,6 +77,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Удалить из закладок',
 	'item.goto_feed': 'Перейти к ленте',
 	'item.visit_the_original': 'Посетить оригинальную ссылку',
+	'item.share': 'Предоставить общий доступ',
 
 	// settings
 	'settings.appearance': 'Внешний вид',

--- a/frontend/src/lib/i18n/langs/sv.ts
+++ b/frontend/src/lib/i18n/langs/sv.ts
@@ -76,6 +76,7 @@ const lang = {
 	'item.remove_from_bookmark': 'Ta bort från bokmärken',
 	'item.goto_feed': 'Gå till flöde',
 	'item.visit_the_original': 'Besök originallänk',
+	'item.share': 'dela',
 
 	// settings
 	'settings.appearance': 'Utseende',

--- a/frontend/src/lib/i18n/langs/zh-Hans.ts
+++ b/frontend/src/lib/i18n/langs/zh-Hans.ts
@@ -75,6 +75,7 @@ const lang = {
 	'item.remove_from_bookmark': '从书签中移除',
 	'item.goto_feed': '前往订阅源',
 	'item.visit_the_original': '访问原始链接',
+	'item.share': '共享',
 
 	// settings
 	'settings.appearance': '外观',

--- a/frontend/src/lib/i18n/langs/zh-Hant.ts
+++ b/frontend/src/lib/i18n/langs/zh-Hant.ts
@@ -74,6 +74,7 @@ const lang = {
 	'item.remove_from_bookmark': '從書籤中移除',
 	'item.goto_feed': '前往訂閱源',
 	'item.visit_the_original': '訪問原始連結',
+	'item.share': '共用',
 
 	// settings
 	'settings.appearance': '外觀',

--- a/frontend/src/routes/(authed)/items/[id]/+page.svelte
+++ b/frontend/src/routes/(authed)/items/[id]/+page.svelte
@@ -59,7 +59,7 @@
 	<ItemActionUnread bind:item enableShortcut={true} />
 	<ItemActionBookmark bind:item enableShortcut={true} />
 	<ItemActionVisitLink {item} enableShortcut={true} />
-	<ItemActionShareLink {item} enableShortcut={true} />
+	<ItemActionShareLink {item} />
 </PageNavHeader>
 
 <div class="relative flex w-full grow justify-around px-4 py-6">

--- a/frontend/src/routes/(authed)/items/[id]/+page.svelte
+++ b/frontend/src/routes/(authed)/items/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import ItemActionGotoFeed from '$lib/components/ItemActionGotoFeed.svelte';
 	import ItemActionUnread from '$lib/components/ItemActionUnread.svelte';
 	import ItemActionVisitLink from '$lib/components/ItemActionVisitLink.svelte';
+	import ItemActionShareLink from '$lib/components/ItemActionShareLink.svelte';
 	import PageNavHeader from '$lib/components/PageNavHeader.svelte';
 	import { render } from '$lib/render-item';
 	import { ExternalLink } from 'lucide-svelte';
@@ -58,6 +59,7 @@
 	<ItemActionUnread bind:item enableShortcut={true} />
 	<ItemActionBookmark bind:item enableShortcut={true} />
 	<ItemActionVisitLink {item} enableShortcut={true} />
+	<ItemActionShareLink {item} enableShortcut={true} />
 </PageNavHeader>
 
 <div class="relative flex w-full grow justify-around px-4 py-6">


### PR DESCRIPTION
This PR aims to solve #171 

- adds a new button to share the link of an item using native [navigator.share](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) API
- only shows the button when share API is supported
- ~~adds a shortcut (s)~~
  - @0x2E would you prefer a different key, or no shortcut at all?
- add localizations for en+de, others missing
  - who can provide translations for other languages? google translate? 🙂 
  - [x] de
  - [x] en
  - [x] es
  - [x] fr
  - [x] pt
  - [x] pt-BR
  - [x] ru
  - [x] sv
  - [x] zh-Hans
  - [x] zh-Hant