### PR TITLE
feat: add support for buttondown.com favicon

### DIFF
--- a/frontend/src/lib/api/favicon.ts
+++ b/frontend/src/lib/api/favicon.ts
@@ -1,6 +1,6 @@
 /**
  *  RSSHub paths mapped to their respective hostname.
- *  Sorted by hostname first then by RSSHub path.
+ *  Sorted by hostname first then by pathname.
  */
 const rssHubMap = {
 	'/papers/category/arxiv': 'arxiv.org',
@@ -16,14 +16,32 @@ const rssHubMap = {
 	'/youtube': 'youtube.com'
 };
 
+/**
+ *  Buttondown.com paths mapped to their respective hostname.
+ *  Sorted by hostname first then by pathname.
+ */
+const buttondownMap = {
+	'/denonews/': 'deno.news'
+};
+
 export function getFavicon(feedLink: string): string {
 	const url = new URL(feedLink);
 	let hostname = url.hostname;
+	let pathname = url.pathname;
 
 	if (hostname.includes('rsshub')) {
 		for (const prefix in rssHubMap) {
-			if (url.pathname.startsWith(prefix)) {
+			if (pathname.startsWith(prefix)) {
 				hostname = rssHubMap[prefix as keyof typeof rssHubMap];
+				break;
+			}
+		}
+	}
+
+	if (hostname === 'buttondown.com') {
+		for (const prefix in buttondownMap) {
+			if (pathname.startsWith(prefix)) {
+				hostname = buttondownMap[prefix as keyof typeof buttondownMap];
 				break;
 			}
 		}


### PR DESCRIPTION
RSS feed from [deno.news](https://deno.news/) actually comes from https://buttondown.com/denonews/rss.

<br/>

|Before|After|
|-|-|
|![Screenshot From 2025-05-24 11-22-10](https://github.com/user-attachments/assets/b1d85893-e120-44c7-8aba-2654faec5686)|![Screenshot From 2025-05-24 11-22-13](https://github.com/user-attachments/assets/e63c55e7-b2e3-428f-b627-775744f67d22)|
