### PR TITLE
Improve article drawer word wrapping

### DIFF
--- a/frontend/src/components/article/article-drawer.tsx
+++ b/frontend/src/components/article/article-drawer.tsx
@@ -237,7 +237,7 @@ export function ArticleDrawer() {
 
             {/* Content */}
             <ScrollArea className="min-h-0 flex-1">
-              <article className="px-5 py-6 sm:px-12 sm:py-8">
+              <article className="min-w-0 px-5 py-6 sm:px-12 sm:py-8">
                 <div className="space-y-3">
                   <h1 className="text-[28px] font-bold leading-[1.3]">
                     {article.title}
@@ -283,7 +283,7 @@ export function ArticleDrawer() {
                 </div>
 
                 <div
-                  className="prose prose-neutral mt-6 max-w-none break-words dark:prose-invert"
+                  className="prose prose-neutral mt-6 min-w-0 max-w-none break-words dark:prose-invert"
                   dangerouslySetInnerHTML={{
                     __html: processArticleContent(
                       article.content,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -137,18 +137,26 @@
 
 /* Article content prose styles */
 .prose {
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   word-wrap: break-word;
-  word-break: break-word;
+  word-break: normal;
 
   pre {
     white-space: pre-wrap;
-    word-break: break-all;
+    overflow-wrap: anywhere;
+    word-break: normal;
     overflow-x: auto;
   }
 
+  pre code {
+    white-space: inherit;
+    overflow-wrap: inherit;
+    word-break: inherit;
+  }
+
   code {
-    word-break: break-all;
+    overflow-wrap: anywhere;
+    word-break: normal;
   }
 
   img {
@@ -157,7 +165,8 @@
   }
 
   a {
-    word-break: break-all;
+    overflow-wrap: anywhere;
+    word-break: normal;
   }
 
   p:empty,


### PR DESCRIPTION
Summary
- allow article drawer contents to shrink by adding `min-w-0` to the article and prose container
- relax prose word-break rules so wrapped text and code blocks stay readable without forcing line breaks

Testing
- Not run (not requested)