### PR TITLE
Remove quotes added by tailwindcss/typography in block quotes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Fusion values simple, maintainable changes over complex abstractions.
 
 Requirements:
 
-- Go `1.25+`
+- Go `1.26+`
 - Node.js `24+`
 - pnpm
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @plugin "@tailwindcss/typography";
+@config "./tailwind.config.js";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/inter";
 

--- a/frontend/src/tailwind.config.js
+++ b/frontend/src/tailwind.config.js
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  theme: {
+    extend: {
+      typography: {
+        DEFAULT: {
+          css: {
+            "blockquote p:first-of-type::before": false,
+            "blockquote p:first-of-type::after": false,
+          },
+        },
+      },
+    },
+  },
+  plugins: [require("@tailwindcss/typography")],
+};


### PR DESCRIPTION
This PR removes automating opening and closing quotes in `<blockquote>` elements.

### Problem

The typography plugin pulled into the frontend CSS adds `open-quote` before the first `<p>` of a `<blockquote>`, and a `close-quote` after the last one. This causes issues when the original feed already contains quotes (note `""` and `"«`/`»"`):

<img width="645" height="177" alt="image" src="https://github.com/user-attachments/assets/8d90d154-50c5-4ab7-b6c3-d4f5edb2e4e4" />

<img width="583" height="93" alt="image" src="https://github.com/user-attachments/assets/10de38da-0386-4169-977c-910b51721301" />

This is also visually inconsistent because often `<blockquote>`s will not contain a `<p>` at all (so no quote is currently added), or the last element may be something like a `<ol>`, in which case the quote would be added nonsensically before it.

### Solution

This PR configures `tailwindcss/typography` to not add these quotes.

Here are the same screenshots as above after applying this patch:

<img width="639" height="171" alt="image" src="https://github.com/user-attachments/assets/91c0244e-8eb3-4c3d-be94-696f67dcf3b2" />

<img width="571" height="97" alt="image" src="https://github.com/user-attachments/assets/793906dc-49dc-468a-b416-3b37fe8e2d8c" />

### Misc

This PR also specifies that go 1.26+ is now required in CONTRIBUTING.md