### PR TITLE
Allow unauthenticated mode when password and OIDC are unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,8 @@ FUSION_DB_PATH=fusion.db
 FUSION_PASSWORD=changeme
 # Fever API username used to derive api_key=md5(username:password) (default: fusion)
 # FUSION_FEVER_USERNAME=fusion
-# Explicitly allow empty password (not recommended)
+# Explicitly allow empty password (not recommended).
+# When password is empty and OIDC is not configured, API auth is disabled.
 # FUSION_ALLOW_EMPTY_PASSWORD=false
 
 # Server Configuration

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ See [Contributing](./CONTRIBUTING.md).
 Most users only need one setting to get started:
 
 - Set `FUSION_PASSWORD`.
+- For local trusted environments only: set `FUSION_ALLOW_EMPTY_PASSWORD=true` to run without auth when OIDC is also disabled.
 
 Then configure based on your goal:
 

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -19,6 +19,7 @@ type Handler struct {
 	config       *config.Config
 	passwordHash string // bcrypt hash computed at startup
 	feverAPIKey  string // md5(username:password) used by Fever API
+	allowAnonAPI bool   // true when both password and OIDC auth are disabled
 	puller       interface {
 		RefreshFeed(ctx context.Context, feedID int64) error
 		RefreshAll(ctx context.Context) (int, error)
@@ -48,9 +49,14 @@ func New(store *store.Store, config *config.Config, puller interface {
 		config:       config,
 		passwordHash: passwordHash,
 		feverAPIKey:  deriveFeverAPIKey(config.FeverUsername, config.Password),
+		allowAnonAPI: strings.TrimSpace(config.Password) == "" && strings.TrimSpace(config.OIDCIssuer) == "",
 		puller:       puller,
 		sessions:     make(map[string]int64),
 		limiter:      newLoginLimiter(config.LoginRateLimit, config.LoginWindow, config.LoginBlock),
+	}
+
+	if h.allowAnonAPI {
+		slog.Warn("authentication is disabled because both password and OIDC are empty")
 	}
 
 	if config.OIDCIssuer != "" {
@@ -207,6 +213,11 @@ func normalizeOrigin(origin string) string {
 
 func (h *Handler) authMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if h.allowAnonAPI {
+			c.Next()
+			return
+		}
+
 		sessionID, err := c.Cookie("session")
 		if err != nil {
 			unauthorizedError(c)

--- a/backend/internal/handler/session_test.go
+++ b/backend/internal/handler/session_test.go
@@ -82,6 +82,7 @@ func TestAuthMiddleware(t *testing.T) {
 		expiresAt     int64
 		wantStatus    int
 		wantStillLive bool
+		allowAnonAPI  bool
 	}{
 		{
 			name:          "rejects expired session and cleans it",
@@ -97,12 +98,21 @@ func TestAuthMiddleware(t *testing.T) {
 			wantStatus:    http.StatusOK,
 			wantStillLive: true,
 		},
+		{
+			name:          "allows requests when auth is disabled",
+			wantStatus:    http.StatusOK,
+			wantStillLive: false,
+			allowAnonAPI:  true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := newTestSessionHandler(t, "secret")
-			h.sessions[tt.token] = tt.expiresAt
+			h.allowAnonAPI = tt.allowAnonAPI
+			if tt.token != "" {
+				h.sessions[tt.token] = tt.expiresAt
+			}
 
 			r := newTestRouter()
 			r.Use(h.authMiddleware())

--- a/docs/frontend-design.md
+++ b/docs/frontend-design.md
@@ -140,7 +140,8 @@ Shortcut help entry points:
 
 ## 10. Authentication UX
 
-- Password login is always available
+- Password login is available when password auth is enabled
+- If password is empty and OIDC is not configured, the UI is directly accessible without `/login`
 - When OIDC is enabled, login page shows "Sign in with OIDC"
 - OIDC callback failure is surfaced as `/login?error=oidc_failed`
 


### PR DESCRIPTION
This changeset allows API routes protected by auth middleware to be accessible when both password and OIDC are unset, matching FUSION_ALLOW_EMPTY_PASSWORD usage. It logs a startup warning when authentication is disabled and keeps Fever API key derivation unchanged. It adds middleware tests for the anonymous mode behavior and updates docs (.env example, README, frontend auth UX docs) to explain the no-auth scenario. Verified with go test ./internal/handler/... and go build -o /dev/null ./cmd/fusion.

Fixes https://github.com/0x2E/fusion/issues/233