### PR TITLE
fix(frontend): stabilize article list pagination state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.db
 *.db-*
 .claude
+.worktrees/
 tmp/
 build/
 dist/

--- a/backend/internal/handler/bookmark.go
+++ b/backend/internal/handler/bookmark.go
@@ -58,6 +58,16 @@ func (h *Handler) listBookmarks(c *gin.Context) {
 	listResponse(c, bookmarks, total)
 }
 
+func (h *Handler) listSavedBookmarkRefs(c *gin.Context) {
+	refs, err := h.store.ListSavedBookmarkRefs()
+	if err != nil {
+		internalError(c, err, "list saved bookmark refs")
+		return
+	}
+
+	dataResponse(c, refs)
+}
+
 func (h *Handler) getBookmark(c *gin.Context) {
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {

--- a/backend/internal/handler/bookmark_test.go
+++ b/backend/internal/handler/bookmark_test.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestListSavedBookmarkRefs(t *testing.T) {
+	h, st := newFeverTestHandler(t)
+
+	group, err := st.CreateGroup("Tech")
+	if err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	feed, err := st.CreateFeed(group.ID, "Fusion Feed", "https://example.com/rss.xml", "https://example.com", "")
+	if err != nil {
+		t.Fatalf("create feed: %v", err)
+	}
+	item, err := st.CreateItem(feed.ID, "guid-1", "Entry 1", "https://example.com/entry-1", "<p>Hello</p>", 1700000000)
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+	bookmark, err := st.CreateBookmark(&item.ID, item.Link, item.Title, item.Content, item.PubDate, feed.Name)
+	if err != nil {
+		t.Fatalf("create bookmark: %v", err)
+	}
+	if _, err := st.CreateBookmark(nil, "https://example.com/orphan", "Orphan", "<p>orphan</p>", 1700000001, feed.Name); err != nil {
+		t.Fatalf("create orphan bookmark: %v", err)
+	}
+
+	r := newTestRouter()
+	r.GET("/api/bookmarks/-/items", h.listSavedBookmarkRefs)
+
+	w := performRequest(r, http.MethodGet, "/api/bookmarks/-/items", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var payload struct {
+		Data []struct {
+			BookmarkID int64 `json:"bookmark_id"`
+			ItemID     int64 `json:"item_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if len(payload.Data) != 1 {
+		t.Fatalf("expected 1 saved bookmark ref, got %d", len(payload.Data))
+	}
+	if payload.Data[0].BookmarkID != bookmark.ID || payload.Data[0].ItemID != item.ID {
+		t.Fatalf("unexpected saved bookmark ref: %#v", payload.Data[0])
+	}
+}

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -137,6 +137,7 @@ func (h *Handler) SetupRouter() *gin.Engine {
 
 			auth.GET("/search", h.search)
 
+			auth.GET("/bookmarks/-/items", h.listSavedBookmarkRefs)
 			auth.GET("/bookmarks", h.listBookmarks)
 			auth.POST("/bookmarks", h.createBookmark)
 			auth.GET("/bookmarks/:id", h.getBookmark)

--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -79,3 +79,9 @@ type Bookmark struct {
 	FeedName  string `json:"feed_name"`
 	CreatedAt int64  `json:"created_at"`
 }
+
+// SavedBookmarkRef links a saved item back to its bookmark id.
+type SavedBookmarkRef struct {
+	BookmarkID int64 `json:"bookmark_id"`
+	ItemID     int64 `json:"item_id"`
+}

--- a/backend/internal/store/bookmark.go
+++ b/backend/internal/store/bookmark.go
@@ -142,3 +142,27 @@ func (s *Store) ListSavedItemIDs() ([]int64, error) {
 
 	return ids, rows.Err()
 }
+
+func (s *Store) ListSavedBookmarkRefs() ([]*model.SavedBookmarkRef, error) {
+	rows, err := s.db.Query(`
+		SELECT id, item_id
+		FROM bookmarks
+		WHERE item_id IS NOT NULL
+		ORDER BY item_id
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	refs := []*model.SavedBookmarkRef{}
+	for rows.Next() {
+		ref := &model.SavedBookmarkRef{}
+		if err := rows.Scan(&ref.BookmarkID, &ref.ItemID); err != nil {
+			return nil, err
+		}
+		refs = append(refs, ref)
+	}
+
+	return refs, rows.Err()
+}

--- a/backend/internal/store/bookmark_test.go
+++ b/backend/internal/store/bookmark_test.go
@@ -196,6 +196,35 @@ func TestDeleteBookmark(t *testing.T) {
 	}
 }
 
+func TestListSavedBookmarkRefs(t *testing.T) {
+	store, _ := setupTestDB(t)
+	defer closeStore(t, store)
+
+	group := mustCreateGroup(t, store, "Test Group")
+	feed := mustCreateFeed(t, store, group.ID, "Test Feed", "https://example.com/feed", "https://example.com", "")
+	firstItem := mustCreateItem(t, store, feed.ID, "guid-1", "First", "https://example.com/1", "Content 1", 123)
+	secondItem := mustCreateItem(t, store, feed.ID, "guid-2", "Second", "https://example.com/2", "Content 2", 124)
+	firstBookmark := mustCreateBookmark(t, store, &firstItem.ID, firstItem.Link, firstItem.Title, firstItem.Content, firstItem.PubDate, feed.Name)
+	secondBookmark := mustCreateBookmark(t, store, &secondItem.ID, secondItem.Link, secondItem.Title, secondItem.Content, secondItem.PubDate, feed.Name)
+	mustCreateBookmark(t, store, nil, "https://example.com/orphan", "Orphan", "Content", 125, feed.Name)
+
+	refs, err := store.ListSavedBookmarkRefs()
+	if err != nil {
+		t.Fatalf("ListSavedBookmarkRefs() failed: %v", err)
+	}
+
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 saved bookmark refs, got %d", len(refs))
+	}
+
+	if refs[0].BookmarkID != firstBookmark.ID || refs[0].ItemID != firstItem.ID {
+		t.Fatalf("unexpected first ref: %#v", refs[0])
+	}
+	if refs[1].BookmarkID != secondBookmark.ID || refs[1].ItemID != secondItem.ID {
+		t.Fatalf("unexpected second ref: %#v", refs[1])
+	}
+}
+
 func TestBookmarkExists(t *testing.T) {
 	store, _ := setupTestDB(t)
 	defer closeStore(t, store)

--- a/docs/superpowers/plans/2026-04-10-article-list-overlay-implementation.md
+++ b/docs/superpowers/plans/2026-04-10-article-list-overlay-implementation.md
@@ -1,0 +1,315 @@
+# Article List Overlay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix unread pagination and starred pagination while preserving the current undo-friendly behavior that keeps modified rows visible until explicit refresh or filter change.
+
+**Architecture:** Keep React Query as the baseline source of paged server data, then layer a small context-aware session overlay on top for local read/star overrides and sticky visibility. Convert bookmarks to infinite pagination and route both `ArticleList` and `ArticleDrawer` through one derived article-list hook so visible rows, navigation, and counters stay consistent.
+
+**Tech Stack:** React 19, TypeScript, TanStack Query, TanStack Router, Zustand, Vite, Go backend verification
+
+---
+
+### Task 1: Bring the Approved Design Into the Branch
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-04-10-article-list-overlay-design.md`
+- Create: `docs/superpowers/plans/2026-04-10-article-list-overlay-implementation.md`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Copy the approved spec into the feature branch**
+
+```md
+# Article List Overlay and Pagination Design
+
+Use the approved spec from the main workspace unchanged so the branch contains the same source of truth that implementation follows.
+```
+
+- [ ] **Step 2: Keep local worktrees ignored in the branch**
+
+```gitignore
+.claude
+.worktrees/
+tmp/
+build/
+```
+
+- [ ] **Step 3: Verify the branch contains the spec and ignore rule**
+
+Run: `git status --short`
+Expected: shows the copied spec, the new plan, and the `.gitignore` update in this branch
+
+
+### Task 2: Replace the Flat Article Session Store With a Context-Aware Overlay
+
+**Files:**
+- Create: `frontend/src/lib/article-list-context.ts`
+- Modify: `frontend/src/store/article-session.ts`
+- Modify: `frontend/src/hooks/use-url-state.ts`
+
+- [ ] **Step 1: Add a reusable list-context key helper**
+
+```ts
+import type { ArticleFilter } from "@/lib/article-filter";
+
+export interface ArticleListContext {
+  filter: ArticleFilter;
+  feedId: number | null;
+  groupId: number | null;
+}
+
+export function getArticleListContextKey(context: ArticleListContext): string {
+  return `${context.filter}:${context.feedId ?? "all"}:${context.groupId ?? "all"}`;
+}
+```
+
+- [ ] **Step 2: Expand the Zustand store from one global override map to per-context overlays**
+
+```ts
+interface ArticleListOverlay {
+  readOverrides: Record<number, boolean>;
+  starOverrides: Record<number, boolean>;
+  stickyVisibleIds: Record<number, true>;
+}
+
+interface ArticleSessionState {
+  overlays: Record<string, ArticleListOverlay>;
+  setReadOverride: (contextKey: string, itemId: number, unread: boolean) => void;
+  setStarOverride: (contextKey: string, itemId: number, starred: boolean) => void;
+  keepVisible: (contextKey: string, itemId: number) => void;
+  clearContext: (contextKey: string) => void;
+}
+```
+
+- [ ] **Step 3: Keep `useUrlState()` as the place that exposes active list context values**
+
+```ts
+return {
+  selectedFeedId,
+  selectedGroupId,
+  selectedArticleId,
+  articleFilter,
+  articleListContext: {
+    filter: articleFilter,
+    feedId: selectedFeedId,
+    groupId: selectedGroupId,
+  },
+  setSelectedFeed,
+  setSelectedGroup,
+  setSelectedArticle,
+  setArticleFilter,
+  selectTopLevelFilter,
+  selectAll,
+};
+```
+
+- [ ] **Step 4: Verify the new types compile cleanly**
+
+Run: `npx tsr generate && npx tsc -b --noEmit`
+Expected: PASS with no TypeScript errors from the new overlay types
+
+
+### Task 3: Convert Bookmarks to Infinite Pagination and Stable Totals
+
+**Files:**
+- Modify: `frontend/src/queries/bookmarks.ts`
+- Modify: `frontend/src/lib/api/index.ts`
+- Modify: `frontend/src/components/feed/feed-list.tsx`
+- Modify: `frontend/src/queries/keys.ts`
+
+- [ ] **Step 1: Add a paginated bookmarks query that mirrors the item-query shape**
+
+```ts
+const bookmarkPageSize = 100;
+
+export const bookmarkQueries = {
+  list: () =>
+    infiniteQueryOptions({
+      queryKey: queryKeys.bookmarks.list(),
+      queryFn: async ({ pageParam }) => bookmarkAPI.list(bookmarkPageSize, pageParam),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages) => {
+        const fetched = allPages.reduce((count, page) => count + page.data.length, 0);
+        return fetched < lastPage.total ? fetched : undefined;
+      },
+    }),
+};
+```
+
+- [ ] **Step 2: Flatten bookmark pages for lookup helpers but keep `total` separate**
+
+```ts
+const pages = data?.pages ?? [];
+const bookmarks = pages.flatMap((page) => page.data);
+const total = pages.at(-1)?.total ?? 0;
+
+return {
+  bookmarks,
+  total,
+  hasNextPage,
+  fetchNextPage,
+  isFetchingNextPage,
+  isItemStarred,
+  getBookmarkByItemId,
+};
+```
+
+- [ ] **Step 3: Switch the sidebar starred count to the server total**
+
+```ts
+const { total: starredCount } = useBookmarkLookup();
+```
+
+- [ ] **Step 4: Verify the starred query path still compiles**
+
+Run: `npx tsr generate && npx tsc -b --noEmit`
+Expected: PASS and no references remain to a single-page bookmarks query
+
+
+### Task 4: Add a Shared Derived Article-List Hook
+
+**Files:**
+- Create: `frontend/src/queries/article-list.ts`
+- Modify: `frontend/src/queries/items.ts`
+- Modify: `frontend/src/queries/bookmarks.ts`
+
+- [ ] **Step 1: Create one derived hook that merges baseline pages with the active overlay**
+
+```ts
+export function useArticleListData(context: ArticleListContext) {
+  const itemsQuery = useItems({
+    feedId: context.feedId,
+    groupId: context.groupId,
+    unread: context.filter === "unread" ? true : undefined,
+  });
+  const bookmarks = useStarredItems({
+    feedId: context.feedId,
+    groupId: context.groupId,
+  });
+  const overlay = useArticleListOverlay(context);
+
+  return buildVisibleArticleList({
+    filter: context.filter,
+    itemPages: itemsQuery.data?.pages ?? [],
+    bookmarks,
+    overlay,
+  });
+}
+```
+
+- [ ] **Step 2: Keep pagination based on baseline server pages only**
+
+```ts
+getNextPageParam: (lastPage, allPages) => {
+  const fetched = allPages.reduce((n, page) => n + page.data.length, 0);
+  return fetched < lastPage.total ? fetched : undefined;
+}
+```
+
+- [ ] **Step 3: Make sticky rows affect rendering, not the fetch cursor**
+
+```ts
+if (filter === "unread" && overlay.stickyVisibleIds[item.id]) {
+  visible.push(applyOverrides(item, overlay));
+  continue;
+}
+```
+
+- [ ] **Step 4: Verify the derived hook leaves load-more math unchanged for baseline pages**
+
+Run: `npx tsr generate && npx tsc -b --noEmit`
+Expected: PASS and the `getNextPageParam` logic still counts only `page.data.length`
+
+
+### Task 5: Rewire ArticleList to Use the Shared Derived List and Overlay Actions
+
+**Files:**
+- Modify: `frontend/src/components/article/article-list.tsx`
+- Modify: `frontend/src/components/feed/feed-list.tsx`
+- Modify: `frontend/src/hooks/use-keyboard.ts`
+
+- [ ] **Step 1: Replace per-component starred/unread override state with the shared hook**
+
+```ts
+const { articleListContext } = useUrlState();
+const articleList = useArticleListData(articleListContext);
+
+const articles = articleList.articles;
+const hasMore = articleList.hasMore;
+const isLoading = articleList.isLoading;
+const isLoadingMore = articleList.isLoadingMore;
+```
+
+- [ ] **Step 2: When local actions change membership, update overlay instead of dropping rows**
+
+```ts
+if (articleFilter === "unread") {
+  articleSession.keepVisible(contextKey, article.id);
+  articleSession.setReadOverride(contextKey, article.id, false);
+}
+
+if (articleFilter === "starred") {
+  articleSession.keepVisible(contextKey, article.id);
+  articleSession.setStarOverride(contextKey, article.id, false);
+}
+```
+
+- [ ] **Step 3: Clear the current context overlay only on explicit reconciliation boundaries**
+
+```ts
+useEffect(() => {
+  return () => {
+    articleSession.clearContext(contextKey);
+  };
+}, [articleSession, contextKey]);
+```
+
+- [ ] **Step 4: Verify list rendering and load-more wiring compile**
+
+Run: `npx tsr generate && npx tsc -b --noEmit`
+Expected: PASS and `ArticleList` uses the shared hook for rows and pagination
+
+
+### Task 6: Rewire ArticleDrawer and Final Verification
+
+**Files:**
+- Modify: `frontend/src/components/article/article-drawer.tsx`
+- Modify: `frontend/src/components/article/article-list.tsx`
+- Modify: `frontend/src/queries/bookmarks.ts`
+- Test: `backend/internal/store/...` (no backend changes expected; run regression suite only)
+
+- [ ] **Step 1: Make the drawer navigate over the same derived article collection as the list**
+
+```ts
+const { articleListContext } = useUrlState();
+const articleList = useArticleListData(articleListContext);
+const listArticles = articleList.articles;
+```
+
+- [ ] **Step 2: Ensure batch mark-as-read uses derived unread state but preserves current-row visibility**
+
+```ts
+const unreadIds = articleList.articles
+  .filter((article) => article.unread && article.id > 0)
+  .map((article) => article.id);
+```
+
+- [ ] **Step 3: Run frontend and backend verification**
+
+Run: `npx tsr generate && npx tsc -b --noEmit`
+Expected: PASS
+
+Run: `go test ./...`
+Expected: PASS
+
+- [ ] **Step 4: Inspect the branch diff before review**
+
+Run: `git status --short && git diff --stat`
+Expected: only the planned frontend files, docs, and `.gitignore` have changed
+
+- [ ] **Step 5: Commit the completed work**
+
+```bash
+git add .gitignore docs/superpowers/specs/2026-04-10-article-list-overlay-design.md docs/superpowers/plans/2026-04-10-article-list-overlay-implementation.md frontend/src/lib/article-list-context.ts frontend/src/store/article-session.ts frontend/src/hooks/use-url-state.ts frontend/src/queries/bookmarks.ts frontend/src/queries/items.ts frontend/src/queries/article-list.ts frontend/src/components/article/article-list.tsx frontend/src/components/article/article-drawer.tsx frontend/src/components/feed/feed-list.tsx frontend/src/hooks/use-keyboard.ts
+git commit -m "fix(frontend): stabilize article list pagination state"
+```

--- a/docs/superpowers/specs/2026-04-10-article-list-overlay-design.md
+++ b/docs/superpowers/specs/2026-04-10-article-list-overlay-design.md
@@ -1,0 +1,249 @@
+# Article List Overlay and Pagination Design
+
+## Summary
+
+Fusion currently has two related classes of article-list bugs:
+
+1. The `starred` view only loads the first 100 bookmarks because the frontend fetches a single `bookmarks` page with `limit=100` and never paginates.
+2. The `unread` view can stop loading additional unread items after local read-state changes because frontend pagination uses `offset`, while the filtered server result set shrinks after articles are marked read.
+
+The intended UX is preserved:
+
+- After marking an article read in the `unread` view, the article should remain visible in the current list.
+- The article should change visually to its new state.
+- The article should not disappear automatically.
+- The list should only fully reconcile with server membership when the user explicitly refreshes or changes filters.
+
+This design fixes those bugs without removing the current optimistic and undo-friendly interaction model.
+
+## Goals
+
+- Fix `starred` so it supports pagination beyond 100 entries.
+- Fix `unread` so local read-state changes do not break further pagination.
+- Preserve local visual state for read/star operations until explicit refresh or filter change.
+- Keep React Query as the source of server data and avoid moving full article collections into a global store.
+- Make the solution reusable across `all`, `unread`, and `starred` article views.
+
+## Non-Goals
+
+- No backend cursor API in this phase.
+- No broad rewrite of feed/group state management.
+- No new persistence format for pending UI state.
+- No change to the product decision that modified entries remain visible until refresh or filter change.
+
+## Root Cause
+
+### Starred
+
+`bookmarks` are fetched via a single query that requests `limit=100, offset=0`. The `starred` list, the sidebar starred count, and starred navigation all derive from that local array, so they are all capped by the first page.
+
+### Unread
+
+`items` uses infinite pagination with `offset = total number of fetched rows`. That is valid only if the filtered server result set remains stable between requests. In the `unread` view, local and server read-state changes shrink the matching result set. When the next request still uses the old offset, later unread items are skipped.
+
+The bug is not caused by optimistic UI itself. It is caused by combining:
+
+- membership-changing filters (`unread`, `starred`),
+- `offset` pagination, and
+- a UI rule that keeps modified rows visible in the current list.
+
+## Design Overview
+
+Introduce a lightweight article-list session overlay layer that sits on top of paged server data.
+
+The model has two distinct parts:
+
+1. **Server baseline**
+   React Query stores paginated `items` and `bookmarks` responses exactly as returned by the API.
+2. **Session overlay**
+   A small frontend session store tracks local read/star overrides and whether already-visible entries should remain visible in the current list even if they no longer satisfy the active filter.
+
+This separation lets pagination continue from server pages while the rendered list continues to honor the current undo-friendly UX.
+
+## Data Model
+
+Add an article list session store keyed by the active list context.
+
+List context fields:
+
+- top-level filter: `all | unread | starred`
+- `feedId`
+- `groupId`
+
+Per-context state:
+
+- `readOverrides: Record<number, boolean>`
+- `starOverrides: Record<number, boolean>`
+- `stickyVisibleIds: Record<number, true>`
+
+Rules:
+
+- In `all`, overrides only affect visuals.
+- In `unread`, marking an already-visible item as read sets `readOverrides[id] = false` and `stickyVisibleIds[id] = true`.
+- In `starred`, un-starring an already-visible item sets `starOverrides[id] = false` and `stickyVisibleIds[id] = true`.
+- Refreshing the list, changing the top-level filter, changing the selected feed, or changing the selected group clears the current context overlay.
+
+The overlay is session-local and intentionally non-persistent.
+
+## Rendering Rules
+
+### All
+
+- Render paged server items.
+- Apply read/star overrides only to display state.
+- Do not change list membership locally.
+
+### Unread
+
+- Baseline membership comes from paged server items with `unread=true`.
+- If an item is already visible and later marked read, keep it rendered in the current list using `stickyVisibleIds`.
+- Its visual state reflects the local read override.
+- The item remains until explicit refresh or filter/context change.
+
+### Starred
+
+- Baseline membership comes from paged bookmark results.
+- If an item is already visible and later unstarred, keep it rendered in the current list using `stickyVisibleIds`.
+- Its visual state reflects the local star override.
+- The item remains until explicit refresh or filter/context change.
+
+## Pagination Rules
+
+The next page cursor must be derived from the number of server rows fetched, not from the number of rows currently rendered.
+
+That means:
+
+- sticky rows do not affect `offset`
+- local membership overrides do not affect `offset`
+- the query layer only counts baseline server pages when computing `getNextPageParam`
+
+This keeps pagination stable even if the visible list contains items that no longer match the current filter.
+
+## Query Changes
+
+### Items
+
+- Keep `useInfiniteQuery` for article items.
+- Preserve current server pagination and totals.
+- Ensure `getNextPageParam` is based only on accumulated server page lengths.
+- Add a derived selector/hook that combines baseline pages with the session overlay into the rendered article list.
+
+### Bookmarks
+
+- Replace the single-page bookmarks query with an infinite query.
+- Keep a derived bookmark lookup for fast `isItemStarred` and `getBookmarkByItemId` checks.
+- Expose bookmark `total` separately from the loaded page count.
+- Render `starred` articles from paginated bookmark pages plus the overlay.
+- Use bookmark `total` for sidebar starred count.
+
+## Component Boundaries
+
+### Query Layer
+
+Responsibilities:
+
+- fetch baseline paged data from APIs
+- expose baseline lookups and totals
+- remain independent from visual sticky behavior
+
+### Article List Session Store
+
+Responsibilities:
+
+- track session-local overrides
+- track sticky visibility for the active context
+- provide clear/reset operations on explicit reconciliation boundaries
+
+### Derived Article List Hook
+
+Responsibilities:
+
+- merge baseline query results with the session overlay
+- provide rendered rows for `ArticleList` and `ArticleDrawer`
+- centralize membership and display rules per filter
+
+This removes the current fragmentation where local state is partly held in component state and partly inferred from query caches.
+
+## Reconciliation Boundaries
+
+The overlay is cleared when the user intentionally leaves the current session view.
+
+Clear on:
+
+- manual refresh of the current list
+- switching top-level filter
+- switching feed
+- switching group
+- re-entering the page with a new context
+
+Do not clear on:
+
+- mark read/unread
+- star/unstar
+- loading more pages inside the same context
+
+## Error Handling
+
+- Keep optimistic mutation rollback for failed read/star operations.
+- On mutation failure, restore both query cache changes and overlay state.
+- Derived list hooks must tolerate missing item details or partially loaded bookmark pages.
+- If a lookup cannot be resolved for a sticky row, keep rendering the best available snapshot rather than removing it abruptly.
+
+## Testing Strategy
+
+### Frontend query and state tests
+
+- `unread` pagination continues to fetch later unread rows after local read changes.
+- `starred` pagination loads beyond the first 100 bookmarks.
+- sidebar starred count uses server `total`, not loaded page length.
+- already-visible rows stay visible after local membership-changing actions.
+- refresh/filter/context change clears sticky rows and overrides.
+
+### Component behavior tests
+
+- `ArticleList` shows modified entries with updated visuals while keeping them in place.
+- `ArticleDrawer` navigation uses the same derived list as `ArticleList`.
+
+### Regression tests
+
+- batch mark-as-read in `unread` does not prevent loading more unread items.
+- un-starring visible rows in `starred` does not break subsequent pagination.
+
+## Implementation Plan
+
+### Phase 1
+
+- Add article list session overlay store.
+- Introduce a shared derived article-list hook.
+- Fix unread pagination to use baseline page counts only.
+- Convert bookmarks to infinite pagination.
+- Update starred count to use bookmark total.
+
+### Phase 2
+
+- Move remaining per-component override state into the shared overlay model.
+- Ensure list, drawer, and keyboard navigation all consume the same derived article collection.
+- Remove duplicated local starred/unread state logic from components.
+
+## Alternatives Considered
+
+### Local patch only
+
+Rejected because it would fix the current symptoms without addressing the structural mismatch between sticky list semantics and membership-changing paged filters.
+
+### Immediate server reconciliation after every action
+
+Rejected because it conflicts with the intended undo-friendly UX.
+
+### Backend cursor pagination first
+
+Deferred because it increases scope across frontend and backend APIs. The current bugs can be fixed cleanly in the frontend with a smaller first step.
+
+## Expected Outcome
+
+After this design is implemented:
+
+- `starred` can paginate through all bookmarks.
+- `unread` can keep modified rows visible without breaking load-more behavior.
+- article list behavior is consistent across list, drawer, and navigation.
+- the current undo-friendly UX is preserved, but the pagination model no longer depends on unstable rendered membership.

--- a/frontend/scripts/article-list-logic.test.ts
+++ b/frontend/scripts/article-list-logic.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  countStickyRemovedRows,
+  countFetchedRows,
+  getAdjustedOffset,
+  mergeStickyArticles,
+} from "../src/queries/article-list-logic.ts";
+
+test("countFetchedRows ignores optimistic bookmark inserts", () => {
+  const fetched = countFetchedRows([
+    {
+      fetchedCount: 100,
+      data: Array.from({ length: 101 }, (_, id) => ({ id })),
+    },
+  ]);
+
+  assert.equal(fetched, 100);
+  assert.equal(getAdjustedOffset(fetched, 0), 100);
+});
+
+test("mergeStickyArticles keeps a sticky snapshot without cached detail", () => {
+  const articles = mergeStickyArticles({
+    baselineArticles: [],
+    stickyVisibleIds: { 42: true },
+    stickyArticles: {
+      42: {
+        id: 42,
+        title: "Saved snapshot",
+      },
+    },
+    getArticleId: (article) => article.id,
+    getCachedArticle: () => undefined,
+  });
+
+  assert.deepEqual(articles, [
+    {
+      id: 42,
+      title: "Saved snapshot",
+    },
+  ]);
+});
+
+test("countStickyRemovedRows keeps removed starred rows in offset math", () => {
+  const removed = countStickyRemovedRows(
+    { 10: true, 11: true },
+    { 10: false, 11: true, 12: false },
+  );
+
+  assert.equal(removed, 1);
+  assert.equal(getAdjustedOffset(100, removed), 99);
+});

--- a/frontend/scripts/bookmark-lookup-logic.test.ts
+++ b/frontend/scripts/bookmark-lookup-logic.test.ts
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Bookmark } from "../src/lib/api/types.ts";
+import {
+  buildSavedBookmarkLookup,
+  resolveBookmarkFeedId,
+  resolveSavedBookmarkId,
+  removeSavedBookmarkRef,
+  upsertSavedBookmarkRef,
+} from "../src/queries/bookmark-lookup-logic.ts";
+
+function makeBookmark(overrides: Partial<Bookmark>): Bookmark {
+  return {
+    id: 1,
+    item_id: 42,
+    link: "https://example.com/article",
+    title: "Saved article",
+    content: "content",
+    pub_date: 1,
+    feed_name: "Feed",
+    created_at: 1,
+    ...overrides,
+  };
+}
+
+test("buildSavedBookmarkLookup returns delete targets without loaded bookmark pages", () => {
+  const lookup = buildSavedBookmarkLookup([
+    { bookmark_id: 7, item_id: 42 },
+    { bookmark_id: 9, item_id: 99 },
+  ]);
+
+  assert.equal(lookup.get(42), 7);
+  assert.equal(lookup.get(99), 9);
+});
+
+test("upsertSavedBookmarkRef replaces the existing saved entry for an item", () => {
+  const updated = upsertSavedBookmarkRef(
+    [
+      { bookmark_id: 1, item_id: 42 },
+      { bookmark_id: 2, item_id: 99 },
+    ],
+    makeBookmark({ id: 11, item_id: 42 }),
+  );
+
+  assert.deepEqual(updated, [
+    { bookmark_id: 11, item_id: 42 },
+    { bookmark_id: 2, item_id: 99 },
+  ]);
+});
+
+test("removeSavedBookmarkRef removes only the deleted bookmark", () => {
+  const updated = removeSavedBookmarkRef(
+    [
+      { bookmark_id: 1, item_id: 42 },
+      { bookmark_id: 2, item_id: 99 },
+    ],
+    2,
+  );
+
+  assert.deepEqual(updated, [{ bookmark_id: 1, item_id: 42 }]);
+});
+
+test("resolveSavedBookmarkId falls back to loaded orphan bookmarks", () => {
+  const savedLookup = buildSavedBookmarkLookup([]);
+  const loadedBookmarks = new Map([[-7, { id: 7 }]]);
+
+  assert.equal(
+    resolveSavedBookmarkId({
+      savedLookup,
+      loadedBookmarks,
+      itemId: -7,
+    }),
+    7,
+  );
+});
+
+test("resolveBookmarkFeedId prefers cached item feed ids over ambiguous feed names", () => {
+  const feedId = resolveBookmarkFeedId({
+    bookmark: makeBookmark({ item_id: 42, feed_name: "Shared Feed" }),
+    uniqueFeedIdByName: new Map(),
+    getCachedFeedId: (itemId) => (itemId === 42 ? 99 : undefined),
+  });
+
+  assert.equal(feedId, 99);
+});

--- a/frontend/src/components/article/article-drawer.tsx
+++ b/frontend/src/components/article/article-drawer.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback } from "react";
 import {
   Circle,
   CircleCheck,
@@ -13,26 +13,17 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useUrlState } from "@/hooks/use-url-state";
 import type { Item } from "@/lib/api";
-import {
-  useItem,
-  useItems,
-  useMarkItemsRead,
-  useMarkItemsUnread,
-} from "@/queries/items";
+import { useItem } from "@/queries/items";
 import { useFeedLookup } from "@/queries/feeds";
-import {
-  useBookmarkLookup,
-  useCreateBookmark,
-  useDeleteBookmark,
-  useStarredItems,
-} from "@/queries/bookmarks";
 import { useArticleNavigation } from "@/hooks/use-keyboard";
+import { useArticleListData } from "@/queries/article-list";
 import { useI18n } from "@/lib/i18n";
 import { formatDate } from "@/lib/utils";
 import { processArticleContent } from "@/lib/content";
 import { getFaviconUrl } from "@/lib/api/favicon";
 import { FeedFavicon } from "@/components/feed/feed-favicon";
 import { toSafeExternalUrl } from "@/lib/safe-url";
+import { useArticleActions } from "./use-article-actions";
 
 export function ArticleDrawer() {
   const { t } = useI18n();
@@ -40,33 +31,14 @@ export function ArticleDrawer() {
     selectedArticleId,
     setSelectedArticle,
     setSelectedFeed,
-    selectedFeedId,
-    selectedGroupId,
     articleFilter,
+    articleListContext,
   } = useUrlState();
+  const articleList = useArticleListData(articleListContext);
   const { getFeedById } = useFeedLookup();
   const isStarredMode = articleFilter === "starred";
-
-  const itemsQuery = useItems({
-    feedId: selectedFeedId,
-    groupId: selectedGroupId,
-    unread: articleFilter === "unread" ? true : undefined,
-  });
-  const articles = useMemo(
-    () => itemsQuery.data?.pages.flatMap((p) => p.data) ?? [],
-    [itemsQuery.data],
-  );
-  const starredArticles = useStarredItems({
-    feedId: selectedFeedId,
-    groupId: selectedGroupId,
-  });
-  const listArticles = isStarredMode ? starredArticles : articles;
-
-  const markRead = useMarkItemsRead();
-  const markUnread = useMarkItemsUnread();
-  const { isItemStarred, getBookmarkByItemId } = useBookmarkLookup();
-  const createBookmark = useCreateBookmark();
-  const deleteBookmark = useDeleteBookmark();
+  const listArticles = articleList.articles;
+  const { toggleRead, toggleStar } = useArticleActions(articleListContext, articleList);
 
   const articleIds = listArticles.map((a) => a.id);
 
@@ -83,14 +55,17 @@ export function ArticleDrawer() {
     shouldFetchArticle,
   );
 
-  const article: Item | null =
-    (isStarredMode ? fetchedArticle ?? storeArticle : storeArticle ?? fetchedArticle) ??
-    null;
+  const article: Item | null = fetchedArticle
+    ? {
+        ...fetchedArticle,
+        unread: storeArticle?.unread ?? fetchedArticle.unread,
+      }
+    : storeArticle;
   const canToggleRead =
     article !== null && article.id > 0 && (!isStarredMode || fetchedArticle !== undefined);
   const feed = article ? getFeedById(article.feed_id) : null;
-  const bookmark = article ? getBookmarkByItemId(article.id) : null;
-  const starred = article ? isItemStarred(article.id) : false;
+  const bookmark = article ? articleList.getBookmarkByItemId(article.id) : null;
+  const starred = article ? articleList.isItemStarred(article.id) : false;
   const safeArticleLink = article ? toSafeExternalUrl(article.link) : null;
 
   const handleOpenChange = (open: boolean) => {
@@ -99,34 +74,25 @@ export function ArticleDrawer() {
     }
   };
 
-  const handleToggleRead = async () => {
+  const handleToggleRead = useCallback(async () => {
     if (!article || !canToggleRead) return;
+
     try {
-      if (article.unread) {
-        await markRead.mutateAsync([article.id]);
-      } else {
-        await markUnread.mutateAsync([article.id]);
-      }
+      await toggleRead(article);
     } catch (error) {
       console.error("Failed to toggle read status:", error);
     }
-  };
+  }, [article, canToggleRead, toggleRead]);
 
-  const handleToggleStar = async () => {
+  const handleToggleStar = useCallback(async () => {
     if (!article) return;
+
     try {
-      if (starred) {
-        const bookmark = getBookmarkByItemId(article.id);
-        if (bookmark) {
-          await deleteBookmark.mutateAsync(bookmark.id);
-        }
-      } else {
-        await createBookmark.mutateAsync(article);
-      }
+      await toggleStar(article);
     } catch (error) {
       console.error("Failed to toggle star:", error);
     }
-  };
+  }, [article, toggleStar]);
 
   const handleOpenOriginal = () => {
     if (!safeArticleLink) return;

--- a/frontend/src/components/article/article-list.tsx
+++ b/frontend/src/components/article/article-list.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { CheckCheck, Loader2 } from "lucide-react";
@@ -10,196 +10,99 @@ import { ContentHeader } from "@/components/layout/content-header";
 import { SidebarTrigger } from "@/components/layout/sidebar-trigger";
 import { useArticleNavigation } from "@/hooks/use-keyboard";
 import { useUrlState, type ArticleFilter } from "@/hooks/use-url-state";
-import {
-  itemQueries,
-  useItems,
-  useMarkItemsRead,
-  useMarkItemsUnread,
-} from "@/queries/items";
+import { getArticleListContextKey } from "@/lib/article-list-context";
+import { itemQueries, useMarkItemsRead } from "@/queries/items";
 import { useFeedLookup } from "@/queries/feeds";
 import { useGroups } from "@/queries/groups";
-import {
-  useBookmarkLookup,
-  useCreateBookmark,
-  useDeleteBookmark,
-  useStarredItems,
-} from "@/queries/bookmarks";
-import { queryKeys } from "@/queries/keys";
+import { useArticleListData } from "@/queries/article-list";
 import { getFaviconUrl } from "@/lib/api/favicon";
 import { useI18n } from "@/lib/i18n";
-import type { Item } from "@/lib/api";
+import { useArticleSessionStore } from "@/store/article-session";
+import { useArticleActions } from "./use-article-actions";
 
 export function ArticleList() {
   const { t } = useI18n();
   const navigate = useNavigate();
   const {
     articleFilter,
+    articleListContext,
     setArticleFilter,
-    selectedFeedId,
-    selectedGroupId,
     selectedArticleId,
     setSelectedArticle,
   } = useUrlState();
   const queryClient = useQueryClient();
-  const [starredUnreadOverrides, setStarredUnreadOverrides] = useState<
-    Record<number, boolean>
-  >({});
-
-  const isStarredMode = articleFilter === "starred";
-
-  // Items query for non-starred modes
-  const itemsQuery = useItems({
-    feedId: selectedFeedId,
-    groupId: selectedGroupId,
-    unread: articleFilter === "unread" ? true : undefined,
-  });
+  const contextKey = getArticleListContextKey(articleListContext);
+  const articleList = useArticleListData(articleListContext);
+  const overlay = useArticleSessionStore(
+    (state) => state.overlays[contextKey],
+  );
+  const keepVisible = useArticleSessionStore((state) => state.keepVisible);
+  const setReadOverride = useArticleSessionStore((state) => state.setReadOverride);
+  const setOverlay = useArticleSessionStore((state) => state.setOverlay);
+  const clearContext = useArticleSessionStore((state) => state.clearContext);
 
   const { data: groups = [] } = useGroups();
   const { feeds, getFeedById, isLoading: isFeedsLoading } = useFeedLookup();
   const markItemsRead = useMarkItemsRead();
-  const markItemsUnread = useMarkItemsUnread();
-  const { isItemStarred, getBookmarkByItemId } = useBookmarkLookup();
-  const createBookmark = useCreateBookmark();
-  const deleteBookmark = useDeleteBookmark();
+  const articles = articleList.articles;
+  const isStarredMode = articleFilter === "starred";
+  const { toggleRead, toggleStar } = useArticleActions(articleListContext, articleList);
 
-  // Flatten infinite query pages
-  const items = useMemo(
-    () => itemsQuery.data?.pages.flatMap((p) => p.data) ?? [],
-    [itemsQuery.data],
-  );
-
-  const starredArticles = useStarredItems({
-    feedId: selectedFeedId,
-    groupId: selectedGroupId,
-  });
-
-  const articles = isStarredMode ? starredArticles : items;
-  const getArticleUnread = useCallback(
-    (article: Item) => {
-      if (!isStarredMode) return article.unread;
-
-      const override = starredUnreadOverrides[article.id];
-      if (override !== undefined) return override;
-
-      if (article.id > 0) {
-        const cachedItem = queryClient.getQueryData<Item>(
-          queryKeys.items.detail(article.id),
-        );
-        if (cachedItem) return cachedItem.unread;
-      }
-
-      return article.unread;
-    },
-    [isStarredMode, queryClient, starredUnreadOverrides],
-  );
-
-  const displayArticles = useMemo(
-    () =>
-      articles.map((article) => ({
-        ...article,
-        unread: getArticleUnread(article),
-      })),
-    [articles, getArticleUnread],
-  );
-
-  const hasMore = isStarredMode ? false : itemsQuery.hasNextPage;
-  const isLoading = isStarredMode ? false : itemsQuery.isLoading;
-  const isLoadingMore = itemsQuery.isFetchingNextPage;
+  useEffect(() => {
+    return () => {
+      clearContext(contextKey);
+    };
+  }, [clearContext, contextKey]);
 
   // Setup keyboard navigation
-  const articleIds = displayArticles.map((a) => a.id);
+  const articleIds = articles.map((a) => a.id);
   useArticleNavigation(articleIds, {
     enabled: selectedArticleId === null,
   });
 
   // Determine title
   let title = t("article.list.all");
-  if (selectedFeedId) {
-    const feed = getFeedById(selectedFeedId);
+  if (articleListContext.feedId) {
+    const feed = getFeedById(articleListContext.feedId);
     title = feed?.name ?? t("article.feedFallback");
-  } else if (selectedGroupId) {
-    const group = groups.find((g) => g.id === selectedGroupId);
+  } else if (articleListContext.groupId) {
+    const group = groups.find((g) => g.id === articleListContext.groupId);
     title = group?.name ?? t("article.groupFallback");
   }
 
-  const unreadCount = displayArticles.filter((a) => a.unread).length;
+  const unreadCount = articles.filter((a) => a.unread).length;
   const hasNoFeeds = !isFeedsLoading && feeds.length === 0;
 
   const handleToggleRead = useCallback(
-    async (article: Item) => {
-      if (isStarredMode && article.id <= 0) {
-        return;
-      }
-
-      let unread = getArticleUnread(article);
-
-      if (isStarredMode && article.id > 0) {
-        try {
-          const detail = await queryClient.ensureQueryData(
-            itemQueries.detail(article.id),
-          );
-          if (detail === undefined) {
-            return;
-          }
-
-          unread = detail.unread;
-        } catch {
-          return;
-        }
-      }
-
+    async (article: (typeof articles)[number]) => {
       try {
-        if (unread) {
-          await markItemsRead.mutateAsync([article.id]);
-        } else {
-          await markItemsUnread.mutateAsync([article.id]);
-        }
-
-        if (isStarredMode) {
-          setStarredUnreadOverrides((prev) => ({
-            ...prev,
-            [article.id]: !unread,
-          }));
-        }
+        await toggleRead(article);
       } catch (error) {
         console.error("Failed to toggle read status:", error);
       }
     },
-    [
-      getArticleUnread,
-      isStarredMode,
-      markItemsRead,
-      markItemsUnread,
-      queryClient,
-    ],
+    [toggleRead],
   );
 
   const handleToggleStar = useCallback(
-    async (article: Item) => {
+    async (article: (typeof articles)[number]) => {
       try {
-        if (isItemStarred(article.id)) {
-          const bookmark = getBookmarkByItemId(article.id);
-          if (bookmark) {
-            await deleteBookmark.mutateAsync(bookmark.id);
-          }
-          return;
-        }
-
-        await createBookmark.mutateAsync(article);
+        await toggleStar(article);
       } catch (error) {
         console.error("Failed to toggle star:", error);
       }
     },
-    [createBookmark, deleteBookmark, getBookmarkByItemId, isItemStarred],
+    [toggleStar],
   );
 
   const handleMarkAllAsRead = async () => {
-    let unreadIds = displayArticles
+    const previousOverlay = overlay;
+    let unreadIds = articles
       .filter((a) => a.unread && a.id > 0)
       .map((a) => a.id);
 
     if (isStarredMode) {
-      const ids = displayArticles.filter((a) => a.id > 0).map((a) => a.id);
+      const ids = articles.filter((a) => a.id > 0).map((a) => a.id);
       const detailEntries = await Promise.all(
         ids.map(async (id) => {
           try {
@@ -221,18 +124,20 @@ export function ArticleList() {
     if (unreadIds.length === 0) return;
 
     try {
-      await markItemsRead.mutateAsync(unreadIds);
-
-      if (isStarredMode) {
-        setStarredUnreadOverrides((prev) => {
-          const next = { ...prev };
-          for (const id of unreadIds) {
-            next[id] = false;
-          }
-          return next;
-        });
+      if (articleFilter === "unread") {
+        for (const id of unreadIds) {
+          keepVisible(contextKey, id);
+          setReadOverride(contextKey, id, false);
+        }
+      } else {
+        for (const id of unreadIds) {
+          setReadOverride(contextKey, id, false);
+        }
       }
+
+      await markItemsRead.mutateAsync(unreadIds);
     } catch (error) {
+      setOverlay(contextKey, previousOverlay);
       console.error("Failed to mark all as read:", error);
     }
   };
@@ -277,7 +182,7 @@ export function ArticleList() {
         {/* Article list */}
         <ScrollArea className="min-h-0 flex-1">
           <div>
-            {isLoading && articles.length === 0 ? (
+            {articleList.isLoading && articles.length === 0 ? (
               <div className="space-y-2 p-2">
                 {[1, 2, 3, 4, 5].map((i) => (
                   <div
@@ -309,9 +214,9 @@ export function ArticleList() {
               )
             ) : (
               <>
-                {displayArticles.map((article) => {
+                {articles.map((article) => {
                   const feed = getFeedById(article.feed_id);
-                  const bookmark = getBookmarkByItemId(article.id);
+                  const bookmark = articleList.getBookmarkByItemId(article.id);
 
                   return (
                     <ArticleItem
@@ -322,7 +227,7 @@ export function ArticleList() {
                       onToggleRead={handleToggleRead}
                       onToggleStar={handleToggleStar}
                       canToggleRead={article.id > 0}
-                      isStarred={isItemStarred(article.id)}
+                      isStarred={articleList.isItemStarred(article.id)}
                       feedName={feed?.name ?? bookmark?.feed_name ?? t("common.unknown")}
                       feedFaviconUrl={
                         feed ? getFaviconUrl(feed.link, feed.site_url) : null
@@ -330,19 +235,21 @@ export function ArticleList() {
                     />
                   );
                 })}
-                {hasMore && (
+                {articleList.hasMore && (
                   <div className="flex justify-center py-4">
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => itemsQuery.fetchNextPage()}
-                      disabled={isLoadingMore}
+                      onClick={() => {
+                        void articleList.loadMore();
+                      }}
+                      disabled={articleList.isLoadingMore}
                       className="gap-2"
                     >
-                      {isLoadingMore && (
+                      {articleList.isLoadingMore && (
                         <Loader2 className="h-4 w-4 animate-spin" />
                       )}
-                      {isLoadingMore
+                      {articleList.isLoadingMore
                         ? t("article.list.loading")
                         : t("article.list.loadMore")}
                     </Button>

--- a/frontend/src/components/article/use-article-actions.ts
+++ b/frontend/src/components/article/use-article-actions.ts
@@ -100,9 +100,9 @@ export function useArticleActions(
         }
 
         if (starred) {
-          const bookmark = articleList.getBookmarkByItemId(article.id);
-          if (bookmark) {
-            await deleteBookmark.mutateAsync(bookmark.id);
+          const bookmarkId = articleList.getSavedBookmarkIdByItemId(article.id);
+          if (bookmarkId !== undefined) {
+            await deleteBookmark.mutateAsync(bookmarkId);
           }
           return;
         }

--- a/frontend/src/components/article/use-article-actions.ts
+++ b/frontend/src/components/article/use-article-actions.ts
@@ -22,6 +22,7 @@ export function useArticleActions(
   const contextKey = getArticleListContextKey(context);
   const overlay = useArticleSessionStore((state) => state.overlays[contextKey]);
   const keepVisible = useArticleSessionStore((state) => state.keepVisible);
+  const setStickyArticle = useArticleSessionStore((state) => state.setStickyArticle);
   const setReadOverride = useArticleSessionStore((state) => state.setReadOverride);
   const setStarOverride = useArticleSessionStore((state) => state.setStarOverride);
   const setOverlay = useArticleSessionStore((state) => state.setOverlay);
@@ -92,6 +93,7 @@ export function useArticleActions(
       try {
         if (context.filter === "starred" && starred) {
           keepVisible(contextKey, article.id);
+          setStickyArticle(contextKey, article);
           setStarOverride(contextKey, article.id, false);
         } else {
           setStarOverride(contextKey, article.id, !starred);
@@ -119,6 +121,7 @@ export function useArticleActions(
       deleteBookmark,
       keepVisible,
       overlay,
+      setStickyArticle,
       setOverlay,
       setStarOverride,
     ],

--- a/frontend/src/components/article/use-article-actions.ts
+++ b/frontend/src/components/article/use-article-actions.ts
@@ -1,0 +1,128 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  getArticleListContextKey,
+  type ArticleListContext,
+} from "@/lib/article-list-context";
+import type { Item } from "@/lib/api";
+import { useCreateBookmark, useDeleteBookmark } from "@/queries/bookmarks";
+import type { ArticleListData } from "@/queries/article-list";
+import {
+  itemQueries,
+  useMarkItemsRead,
+  useMarkItemsUnread,
+} from "@/queries/items";
+import { useArticleSessionStore } from "@/store/article-session";
+
+export function useArticleActions(
+  context: ArticleListContext,
+  articleList: ArticleListData,
+) {
+  const queryClient = useQueryClient();
+  const contextKey = getArticleListContextKey(context);
+  const overlay = useArticleSessionStore((state) => state.overlays[contextKey]);
+  const keepVisible = useArticleSessionStore((state) => state.keepVisible);
+  const setReadOverride = useArticleSessionStore((state) => state.setReadOverride);
+  const setStarOverride = useArticleSessionStore((state) => state.setStarOverride);
+  const setOverlay = useArticleSessionStore((state) => state.setOverlay);
+  const markRead = useMarkItemsRead();
+  const markUnread = useMarkItemsUnread();
+  const createBookmark = useCreateBookmark();
+  const deleteBookmark = useDeleteBookmark();
+  const isStarredMode = context.filter === "starred";
+
+  const toggleRead = useCallback(
+    async (article: Item) => {
+      if (article.id <= 0) {
+        return;
+      }
+
+      const previousOverlay = overlay;
+      let unread = article.unread;
+
+      if (isStarredMode) {
+        try {
+          const detail = await queryClient.ensureQueryData(itemQueries.detail(article.id));
+          if (detail === undefined) {
+            return;
+          }
+
+          unread = detail.unread;
+        } catch {
+          return;
+        }
+      }
+
+      try {
+        setReadOverride(contextKey, article.id, !unread);
+
+        if (context.filter === "unread" && unread) {
+          keepVisible(contextKey, article.id);
+        }
+
+        if (unread) {
+          await markRead.mutateAsync([article.id]);
+        } else {
+          await markUnread.mutateAsync([article.id]);
+        }
+      } catch (error) {
+        setOverlay(contextKey, previousOverlay);
+        throw error;
+      }
+    },
+    [
+      context.filter,
+      contextKey,
+      isStarredMode,
+      keepVisible,
+      markRead,
+      markUnread,
+      overlay,
+      queryClient,
+      setOverlay,
+      setReadOverride,
+    ],
+  );
+
+  const toggleStar = useCallback(
+    async (article: Item) => {
+      const previousOverlay = overlay;
+      const starred = articleList.isItemStarred(article.id);
+
+      try {
+        if (context.filter === "starred" && starred) {
+          keepVisible(contextKey, article.id);
+          setStarOverride(contextKey, article.id, false);
+        } else {
+          setStarOverride(contextKey, article.id, !starred);
+        }
+
+        if (starred) {
+          const bookmark = articleList.getBookmarkByItemId(article.id);
+          if (bookmark) {
+            await deleteBookmark.mutateAsync(bookmark.id);
+          }
+          return;
+        }
+
+        await createBookmark.mutateAsync(article);
+      } catch (error) {
+        setOverlay(contextKey, previousOverlay);
+        throw error;
+      }
+    },
+    [
+      articleList,
+      context.filter,
+      contextKey,
+      createBookmark,
+      deleteBookmark,
+      keepVisible,
+      overlay,
+      setOverlay,
+      setStarOverride,
+    ],
+  );
+
+  return { toggleRead, toggleStar };
+}

--- a/frontend/src/components/feed/feed-list.tsx
+++ b/frontend/src/components/feed/feed-list.tsx
@@ -16,7 +16,7 @@ export function FeedList() {
   const { data: groups = [], isLoading } = useGroups();
   const { feeds, getFeedsByGroup } = useFeedLookup();
   const { getTotalUnreadCount } = useUnreadCounts();
-  const { bookmarks } = useBookmarkLookup();
+  const { total: starredCount } = useBookmarkLookup();
   const {
     selectedFeedId,
     selectedGroupId,
@@ -30,7 +30,6 @@ export function FeedList() {
   const isTopLevelSelected =
     isOnHomePage && selectedFeedId === null && selectedGroupId === null;
   const totalUnread = getTotalUnreadCount();
-  const starredCount = bookmarks.length;
 
   const topFilters: Array<{
     value: "all" | "unread" | "starred";

--- a/frontend/src/hooks/use-url-state.ts
+++ b/frontend/src/hooks/use-url-state.ts
@@ -9,6 +9,7 @@ import {
   isArticleFilter,
   type ArticleFilter,
 } from "@/lib/article-filter";
+import { type ArticleListContext } from "@/lib/article-list-context";
 import { parsePositiveIntegerParam } from "@/lib/route-params";
 
 export type { ArticleFilter } from "@/lib/article-filter";
@@ -33,6 +34,11 @@ export function useUrlState() {
   const selectedFeedId = routeFeedId;
   const selectedGroupId = routeGroupId;
   const articleFilter = routeFilter;
+  const articleListContext: ArticleListContext = {
+    filter: articleFilter,
+    feedId: selectedFeedId,
+    groupId: selectedGroupId,
+  };
 
   const navigateToList = useCallback(
     ({
@@ -164,6 +170,7 @@ export function useUrlState() {
     selectedGroupId,
     selectedArticleId,
     articleFilter,
+    articleListContext,
     setSelectedFeed,
     setSelectedGroup,
     setSelectedArticle,

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -7,6 +7,7 @@ import type {
   Feed,
   Item,
   Bookmark,
+  SavedBookmarkRef,
   CreateGroupRequest,
   UpdateGroupRequest,
   CreateFeedRequest,
@@ -106,6 +107,8 @@ export const itemAPI = {
 
 // Bookmark APIs
 export const bookmarkAPI = {
+  listSavedItemRefs: () => api.get<APIResponse<SavedBookmarkRef[]>>("/bookmarks/-/items"),
+
   list: (limit = 50, offset = 0) => {
     const query = new URLSearchParams({
       limit: limit.toString(),

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -59,6 +59,11 @@ export interface Bookmark {
   created_at: number;
 }
 
+export interface SavedBookmarkRef {
+  bookmark_id: number;
+  item_id: number;
+}
+
 // API response wrappers
 export interface APIResponse<T> {
   data?: T;

--- a/frontend/src/lib/article-list-context.ts
+++ b/frontend/src/lib/article-list-context.ts
@@ -1,0 +1,11 @@
+import type { ArticleFilter } from "@/lib/article-filter";
+
+export interface ArticleListContext {
+  filter: ArticleFilter;
+  feedId: number | null;
+  groupId: number | null;
+}
+
+export function getArticleListContextKey(context: ArticleListContext): string {
+  return `${context.filter}:${context.feedId ?? "all"}:${context.groupId ?? "all"}`;
+}

--- a/frontend/src/queries/article-list-logic.ts
+++ b/frontend/src/queries/article-list-logic.ts
@@ -1,0 +1,50 @@
+export function countFetchedRows<T extends { fetchedCount: number }>(
+  pages: T[],
+): number {
+  return pages.reduce((count, page) => count + page.fetchedCount, 0);
+}
+
+export function getAdjustedOffset(
+  loadedCount: number,
+  removedCount: number,
+): number {
+  return Math.max(0, loadedCount - removedCount);
+}
+
+export function countStickyRemovedRows(
+  stickyVisibleIds: Record<number, true>,
+  membershipOverrides: Record<number, boolean>,
+): number {
+  return Object.keys(stickyVisibleIds).filter(
+    (id) => membershipOverrides[Number(id)] === false,
+  ).length;
+}
+
+export function mergeStickyArticles<T>(args: {
+  baselineArticles: T[];
+  stickyVisibleIds: Record<number, true>;
+  stickyArticles: Record<number, T>;
+  getArticleId: (article: T) => number;
+  getCachedArticle?: (id: number) => T | undefined;
+}): T[] {
+  const articleById = new Map<number, T>();
+
+  for (const article of args.baselineArticles) {
+    articleById.set(args.getArticleId(article), article);
+  }
+
+  for (const stickyId of Object.keys(args.stickyVisibleIds)) {
+    const articleId = Number(stickyId);
+    if (articleById.has(articleId)) {
+      continue;
+    }
+
+    const article =
+      args.stickyArticles[articleId] ?? args.getCachedArticle?.(articleId);
+    if (article) {
+      articleById.set(articleId, article);
+    }
+  }
+
+  return Array.from(articleById.values());
+}

--- a/frontend/src/queries/article-list.ts
+++ b/frontend/src/queries/article-list.ts
@@ -17,6 +17,11 @@ import {
   useBookmarkLookup,
   useStarredItems,
 } from "./bookmarks";
+import {
+  countStickyRemovedRows,
+  getAdjustedOffset,
+  mergeStickyArticles,
+} from "./article-list-logic";
 import { queryKeys } from "./keys";
 import { fetchItemsPage, itemQueries, type ItemListResponse, useItems } from "./items";
 
@@ -57,7 +62,7 @@ export function useArticleListData(context: ArticleListContext): ArticleListData
     groupId: context.groupId,
   });
   const {
-    bookmarks,
+    fetchedCount: fetchedBookmarkCount,
     total: bookmarkTotal,
     getBookmarkByItemId,
     isItemStarred: isBaselineItemStarred,
@@ -71,45 +76,49 @@ export function useArticleListData(context: ArticleListContext): ArticleListData
       count + page.data.filter((article) => overlay.readOverrides[article.id] === false).length,
     0,
   );
-  const starredLoadedCount = bookmarks.length;
-  const starredRemovedCount = bookmarks.filter(
-    (bookmark) => overlay.starOverrides[bookmark.item_id ?? -bookmark.id] === false,
-  ).length;
-  const adjustedUnreadOffset = Math.max(0, unreadLoadedCount - unreadRemovedCount);
-  const adjustedStarredOffset = Math.max(0, starredLoadedCount - starredRemovedCount);
+  const starredLoadedCount = fetchedBookmarkCount;
+  const starredRemovedCount = countStickyRemovedRows(
+    overlay.stickyVisibleIds,
+    overlay.starOverrides,
+  );
+  const adjustedUnreadOffset = getAdjustedOffset(
+    unreadLoadedCount,
+    unreadRemovedCount,
+  );
+  const adjustedStarredOffset = getAdjustedOffset(
+    starredLoadedCount,
+    starredRemovedCount,
+  );
 
   const articles = useMemo(() => {
     const baselineArticles =
       context.filter === "starred"
         ? starredItems.articles
         : itemsQuery.data?.pages.flatMap((page) => page.data) ?? [];
-    const articleById = new Map<number, Item>();
+    const visibleArticles = mergeStickyArticles({
+      baselineArticles,
+      stickyVisibleIds: overlay.stickyVisibleIds,
+      stickyArticles: overlay.stickyArticles,
+      getArticleId: (article) => article.id,
+      getCachedArticle: (itemId) => {
+        if (itemId <= 0) {
+          return undefined;
+        }
 
-    for (const article of baselineArticles) {
-      if (context.filter === "starred" && article.id > 0) {
-        const cachedItem = queryClient.getQueryData<Item>(
-          queryKeys.items.detail(article.id),
-        );
-        articleById.set(article.id, cachedItem ?? article);
-        continue;
+        return queryClient.getQueryData<Item>(queryKeys.items.detail(itemId));
+      },
+    }).map((article) => {
+      if (context.filter !== "starred" || article.id <= 0) {
+        return article;
       }
 
-      articleById.set(article.id, article);
-    }
+      const cachedItem = queryClient.getQueryData<Item>(
+        queryKeys.items.detail(article.id),
+      );
+      return cachedItem ?? article;
+    });
 
-    for (const stickyId of Object.keys(overlay.stickyVisibleIds)) {
-      const itemId = Number(stickyId);
-      if (articleById.has(itemId) || itemId <= 0) {
-        continue;
-      }
-
-      const cachedItem = queryClient.getQueryData<Item>(queryKeys.items.detail(itemId));
-      if (cachedItem) {
-        articleById.set(itemId, cachedItem);
-      }
-    }
-
-    return Array.from(articleById.values())
+    return visibleArticles
       .filter((article) => {
         if (context.filter === "all") {
           return true;
@@ -129,6 +138,7 @@ export function useArticleListData(context: ArticleListContext): ArticleListData
     itemsQuery.data,
     overlay.readOverrides,
     overlay.starOverrides,
+    overlay.stickyArticles,
     overlay.stickyVisibleIds,
     queryClient,
     starredItems.articles,

--- a/frontend/src/queries/article-list.ts
+++ b/frontend/src/queries/article-list.ts
@@ -33,6 +33,7 @@ export interface ArticleListData {
   loadMore: () => Promise<unknown>;
   isItemStarred: (itemId: number) => boolean;
   getBookmarkByItemId: (itemId: number) => Bookmark | undefined;
+  getSavedBookmarkIdByItemId: (itemId: number) => number | undefined;
 }
 
 function applyArticleOverrides(
@@ -65,6 +66,7 @@ export function useArticleListData(context: ArticleListContext): ArticleListData
     fetchedCount: fetchedBookmarkCount,
     total: bookmarkTotal,
     getBookmarkByItemId,
+    getSavedBookmarkIdByItemId,
     isItemStarred: isBaselineItemStarred,
     isLoading: isBookmarksLoading,
   } = useBookmarkLookup();
@@ -297,5 +299,7 @@ export function useArticleListData(context: ArticleListContext): ArticleListData
     isItemStarred,
     getBookmarkByItemId: (itemId: number): Bookmark | undefined =>
       getBookmarkByItemId(itemId),
+    getSavedBookmarkIdByItemId: (itemId: number): number | undefined =>
+      getSavedBookmarkIdByItemId(itemId),
   };
 }

--- a/frontend/src/queries/article-list.ts
+++ b/frontend/src/queries/article-list.ts
@@ -1,0 +1,291 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { type InfiniteData, useQueryClient } from "@tanstack/react-query";
+import type { Bookmark, Item } from "@/lib/api";
+import {
+  getArticleListContextKey,
+  type ArticleListContext,
+} from "@/lib/article-list-context";
+import {
+  createEmptyArticleListOverlay,
+  useArticleSessionStore,
+} from "@/store/article-session";
+import { usePreferencesStore } from "@/store";
+import {
+  bookmarkQueries,
+  fetchBookmarkPage,
+  type BookmarkPage,
+  useBookmarkLookup,
+  useStarredItems,
+} from "./bookmarks";
+import { queryKeys } from "./keys";
+import { fetchItemsPage, itemQueries, type ItemListResponse, useItems } from "./items";
+
+export interface ArticleListData {
+  articles: Item[];
+  hasMore: boolean | undefined;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  loadMore: () => Promise<unknown>;
+  isItemStarred: (itemId: number) => boolean;
+  getBookmarkByItemId: (itemId: number) => Bookmark | undefined;
+}
+
+function applyArticleOverrides(
+  article: Item,
+  readOverrides: Record<number, boolean>,
+): Item {
+  const unread = readOverrides[article.id];
+  return unread === undefined ? article : { ...article, unread };
+}
+
+export function useArticleListData(context: ArticleListContext): ArticleListData {
+  const queryClient = useQueryClient();
+  const articlePageSize = usePreferencesStore((state) => state.articlePageSize);
+  const inFlightOffsetsRef = useRef(new Set<string>());
+  const [isManualLoadingMore, setIsManualLoadingMore] = useState(false);
+  const contextKey = getArticleListContextKey(context);
+  const overlay = useArticleSessionStore(
+    (state) => state.overlays[contextKey] ?? createEmptyArticleListOverlay(),
+  );
+  const itemsQuery = useItems({
+    feedId: context.feedId,
+    groupId: context.groupId,
+    unread: context.filter === "unread" ? true : undefined,
+  });
+  const starredItems = useStarredItems({
+    feedId: context.feedId,
+    groupId: context.groupId,
+  });
+  const {
+    bookmarks,
+    total: bookmarkTotal,
+    getBookmarkByItemId,
+    isItemStarred: isBaselineItemStarred,
+    isLoading: isBookmarksLoading,
+  } = useBookmarkLookup();
+  const itemPages = itemsQuery.data?.pages ?? [];
+  const unreadTotal = itemPages.at(-1)?.total ?? 0;
+  const unreadLoadedCount = itemPages.reduce((count, page) => count + page.data.length, 0);
+  const unreadRemovedCount = itemPages.reduce(
+    (count, page) =>
+      count + page.data.filter((article) => overlay.readOverrides[article.id] === false).length,
+    0,
+  );
+  const starredLoadedCount = bookmarks.length;
+  const starredRemovedCount = bookmarks.filter(
+    (bookmark) => overlay.starOverrides[bookmark.item_id ?? -bookmark.id] === false,
+  ).length;
+  const adjustedUnreadOffset = Math.max(0, unreadLoadedCount - unreadRemovedCount);
+  const adjustedStarredOffset = Math.max(0, starredLoadedCount - starredRemovedCount);
+
+  const articles = useMemo(() => {
+    const baselineArticles =
+      context.filter === "starred"
+        ? starredItems.articles
+        : itemsQuery.data?.pages.flatMap((page) => page.data) ?? [];
+    const articleById = new Map<number, Item>();
+
+    for (const article of baselineArticles) {
+      if (context.filter === "starred" && article.id > 0) {
+        const cachedItem = queryClient.getQueryData<Item>(
+          queryKeys.items.detail(article.id),
+        );
+        articleById.set(article.id, cachedItem ?? article);
+        continue;
+      }
+
+      articleById.set(article.id, article);
+    }
+
+    for (const stickyId of Object.keys(overlay.stickyVisibleIds)) {
+      const itemId = Number(stickyId);
+      if (articleById.has(itemId) || itemId <= 0) {
+        continue;
+      }
+
+      const cachedItem = queryClient.getQueryData<Item>(queryKeys.items.detail(itemId));
+      if (cachedItem) {
+        articleById.set(itemId, cachedItem);
+      }
+    }
+
+    return Array.from(articleById.values())
+      .filter((article) => {
+        if (context.filter === "all") {
+          return true;
+        }
+
+        if (context.filter === "unread") {
+          const unread = overlay.readOverrides[article.id] ?? article.unread;
+          return unread || overlay.stickyVisibleIds[article.id] === true;
+        }
+
+        const starred = overlay.starOverrides[article.id] ?? true;
+        return starred || overlay.stickyVisibleIds[article.id] === true;
+      })
+      .map((article) => applyArticleOverrides(article, overlay.readOverrides));
+  }, [
+    context.filter,
+    itemsQuery.data,
+    overlay.readOverrides,
+    overlay.starOverrides,
+    overlay.stickyVisibleIds,
+    queryClient,
+    starredItems.articles,
+  ]);
+
+  const isItemStarred = useCallback(
+    (itemId: number) => overlay.starOverrides[itemId] ?? isBaselineItemStarred(itemId),
+    [isBaselineItemStarred, overlay.starOverrides],
+  );
+
+  const appendItemsPage = useCallback(
+    async (offset: number) => {
+      const requestKey = `unread:${offset}`;
+      if (inFlightOffsetsRef.current.has(requestKey)) {
+        return undefined;
+      }
+
+      const query = itemQueries.list(
+        {
+          feedId: context.feedId,
+          groupId: context.groupId,
+          unread: true,
+        },
+        articlePageSize,
+      );
+
+      inFlightOffsetsRef.current.add(requestKey);
+      setIsManualLoadingMore(true);
+
+      try {
+        const page = await fetchItemsPage(
+          {
+            feedId: context.feedId,
+            groupId: context.groupId,
+            unread: true,
+          },
+          articlePageSize,
+          offset,
+        );
+
+        queryClient.setQueryData<InfiniteData<ItemListResponse, number>>(
+          query.queryKey,
+          (old) => {
+            if (!old) {
+              return {
+                pages: [page],
+                pageParams: [offset],
+              };
+            }
+
+            const existingIndex = old.pageParams.indexOf(offset);
+            if (existingIndex !== -1) {
+              const nextPages = [...old.pages];
+              nextPages[existingIndex] = page;
+
+              return {
+                ...old,
+                pages: nextPages,
+              };
+            }
+
+            return {
+              ...old,
+              pages: [...old.pages, page],
+              pageParams: [...old.pageParams, offset],
+            };
+          },
+        );
+
+        return page;
+      } finally {
+        inFlightOffsetsRef.current.delete(requestKey);
+        setIsManualLoadingMore(inFlightOffsetsRef.current.size > 0);
+      }
+    },
+    [articlePageSize, context.feedId, context.groupId, queryClient],
+  );
+
+  const appendBookmarkPage = useCallback(
+    async (offset: number) => {
+      const requestKey = `starred:${offset}`;
+      if (inFlightOffsetsRef.current.has(requestKey)) {
+        return undefined;
+      }
+
+      const queryKey = bookmarkQueries.list().queryKey;
+      inFlightOffsetsRef.current.add(requestKey);
+      setIsManualLoadingMore(true);
+
+      try {
+        const page = await fetchBookmarkPage(offset);
+
+        queryClient.setQueryData<InfiniteData<BookmarkPage, number>>(
+          queryKey,
+          (old) => {
+            if (!old) {
+              return {
+                pages: [page],
+                pageParams: [offset],
+              };
+            }
+
+            const existingIndex = old.pageParams.indexOf(offset);
+            if (existingIndex !== -1) {
+              const nextPages = [...old.pages];
+              nextPages[existingIndex] = page;
+
+              return {
+                ...old,
+                pages: nextPages,
+              };
+            }
+
+            return {
+              ...old,
+              pages: [...old.pages, page],
+              pageParams: [...old.pageParams, offset],
+            };
+          },
+        );
+
+        return page;
+      } finally {
+        inFlightOffsetsRef.current.delete(requestKey);
+        setIsManualLoadingMore(inFlightOffsetsRef.current.size > 0);
+      }
+    },
+    [queryClient],
+  );
+
+  return {
+    articles,
+    hasMore:
+      context.filter === "unread"
+        ? adjustedUnreadOffset < unreadTotal
+        : context.filter === "starred"
+          ? adjustedStarredOffset < bookmarkTotal
+          : itemsQuery.hasNextPage,
+    isLoading:
+      context.filter === "starred" ? isBookmarksLoading : itemsQuery.isLoading,
+    isLoadingMore:
+      context.filter === "unread" || context.filter === "starred"
+        ? isManualLoadingMore
+        : itemsQuery.isFetchingNextPage,
+    loadMore: () => {
+      if (context.filter === "unread") {
+        return appendItemsPage(adjustedUnreadOffset);
+      }
+
+      if (context.filter === "starred") {
+        return appendBookmarkPage(adjustedStarredOffset);
+      }
+
+      return itemsQuery.fetchNextPage();
+    },
+    isItemStarred,
+    getBookmarkByItemId: (itemId: number): Bookmark | undefined =>
+      getBookmarkByItemId(itemId),
+  };
+}

--- a/frontend/src/queries/bookmark-lookup-logic.ts
+++ b/frontend/src/queries/bookmark-lookup-logic.ts
@@ -1,0 +1,64 @@
+import type { Bookmark, SavedBookmarkRef } from "@/lib/api";
+
+export function buildSavedBookmarkLookup(
+  savedRefs: SavedBookmarkRef[],
+): Map<number, number> {
+  return new Map(savedRefs.map((ref) => [ref.item_id, ref.bookmark_id]));
+}
+
+export function resolveSavedBookmarkId(args: {
+  savedLookup: Map<number, number>;
+  loadedBookmarks: Map<number, Pick<Bookmark, "id">>;
+  itemId: number;
+}): number | undefined {
+  return args.savedLookup.get(args.itemId) ?? args.loadedBookmarks.get(args.itemId)?.id;
+}
+
+export function resolveBookmarkFeedId(args: {
+  bookmark: Pick<Bookmark, "item_id" | "feed_name">;
+  uniqueFeedIdByName: Map<string, number>;
+  getCachedFeedId?: (itemId: number) => number | undefined;
+}): number {
+  if (args.bookmark.item_id && args.bookmark.item_id > 0) {
+    const cachedFeedId = args.getCachedFeedId?.(args.bookmark.item_id);
+    if (cachedFeedId !== undefined) {
+      return cachedFeedId;
+    }
+  }
+
+  return args.uniqueFeedIdByName.get(args.bookmark.feed_name) ?? 0;
+}
+
+export function upsertSavedBookmarkRef(
+  savedRefs: SavedBookmarkRef[] | undefined,
+  bookmark: Pick<Bookmark, "id" | "item_id">,
+): SavedBookmarkRef[] | undefined {
+  if (bookmark.item_id === null || bookmark.item_id <= 0) {
+    return savedRefs;
+  }
+
+  const nextRef: SavedBookmarkRef = {
+    bookmark_id: bookmark.id,
+    item_id: bookmark.item_id,
+  };
+
+  if (!savedRefs) {
+    return [nextRef];
+  }
+
+  const index = savedRefs.findIndex((ref) => ref.item_id === bookmark.item_id);
+  if (index === -1) {
+    return [nextRef, ...savedRefs];
+  }
+
+  const next = [...savedRefs];
+  next[index] = nextRef;
+  return next;
+}
+
+export function removeSavedBookmarkRef(
+  savedRefs: SavedBookmarkRef[] | undefined,
+  bookmarkId: number,
+): SavedBookmarkRef[] | undefined {
+  return savedRefs?.filter((ref) => ref.bookmark_id !== bookmarkId);
+}

--- a/frontend/src/queries/bookmarks.ts
+++ b/frontend/src/queries/bookmarks.ts
@@ -13,6 +13,7 @@ import {
   type Item,
   type ListAPIResponse,
 } from "@/lib/api";
+import { countFetchedRows } from "./article-list-logic";
 import { useFeedLookup } from "./feeds";
 import { queryKeys } from "./keys";
 
@@ -187,6 +188,7 @@ export function useBookmarkLookup() {
   } = useBookmarks();
   const pages = data?.pages ?? [];
   const bookmarks = useMemo(() => pages.flatMap((page) => page.data), [pages]);
+  const fetchedCount = useMemo(() => countFetchedRows(pages), [pages]);
   const total = pages.at(-1)?.total ?? 0;
 
   const byArticleId = useMemo(
@@ -206,6 +208,7 @@ export function useBookmarkLookup() {
 
   return {
     bookmarks,
+    fetchedCount,
     total,
     hasNextPage,
     fetchNextPage,

--- a/frontend/src/queries/bookmarks.ts
+++ b/frontend/src/queries/bookmarks.ts
@@ -1,47 +1,202 @@
 import { useCallback, useMemo } from "react";
 import {
-  queryOptions,
+  type QueryClient,
+  type InfiniteData,
+  infiniteQueryOptions,
+  useInfiniteQuery,
   useMutation,
-  useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { bookmarkAPI, type Bookmark, type Item } from "@/lib/api";
-import { useArticleSessionStore } from "@/store/article-session";
-import { queryKeys } from "./keys";
+import {
+  bookmarkAPI,
+  type Bookmark,
+  type Item,
+  type ListAPIResponse,
+} from "@/lib/api";
 import { useFeedLookup } from "./feeds";
+import { queryKeys } from "./keys";
+
+type CachedItemPages = {
+  pages: Array<{ data: Item[] }>;
+};
+
+function getCachedItemById(queryClient: QueryClient, itemId: number): Item | undefined {
+  const detailItem = queryClient.getQueryData<Item>(queryKeys.items.detail(itemId));
+  if (detailItem) {
+    return detailItem;
+  }
+
+  const itemLists = queryClient.getQueriesData<CachedItemPages>({
+    queryKey: queryKeys.items.lists(),
+  });
+
+  for (const [, data] of itemLists) {
+    const item = data?.pages.flatMap((page) => page.data).find((entry) => entry.id === itemId);
+    if (item) {
+      return item;
+    }
+  }
+
+  return undefined;
+}
 
 function resolveBookmarkItemId(bookmark: Bookmark): number {
   return bookmark.item_id ?? -bookmark.id;
 }
 
+export type BookmarkPage = ListAPIResponse<Bookmark> & { fetchedCount: number };
+type BookmarkInfiniteData = InfiniteData<BookmarkPage, number>;
+
+const bookmarkPageSize = 100;
+
+function updateBookmarkPages(
+  old: BookmarkInfiniteData | undefined,
+  updater: (page: BookmarkPage, pageIndex: number) => BookmarkPage,
+  totalDelta: number,
+): BookmarkInfiniteData | undefined {
+  if (!old) {
+    return old;
+  }
+
+  return {
+    ...old,
+    pages: old.pages.map((page, index) => ({
+      ...updater(page, index),
+      total: Math.max(0, page.total + totalDelta),
+      fetchedCount: page.fetchedCount,
+    })),
+  };
+}
+
+function upsertBookmarkInPages(
+  old: BookmarkInfiniteData | undefined,
+  bookmark: Bookmark,
+): BookmarkInfiniteData | undefined {
+  if (!old) {
+    return old;
+  }
+
+  const itemId = resolveBookmarkItemId(bookmark);
+  const exists = old.pages.some((page) =>
+    page.data.some(
+      (entry) => resolveBookmarkItemId(entry) === itemId || entry.id === bookmark.id,
+    ),
+  );
+
+  return updateBookmarkPages(
+    old,
+    (page, index) => {
+      const existingIndex = page.data.findIndex(
+        (entry) => resolveBookmarkItemId(entry) === itemId || entry.id === bookmark.id,
+      );
+      if (existingIndex !== -1) {
+        const data = [...page.data];
+        data[existingIndex] = bookmark;
+        return { ...page, data };
+      }
+
+      if (!exists && index === 0) {
+        return { ...page, data: [bookmark, ...page.data] };
+      }
+
+      return page;
+    },
+    exists ? 0 : 1,
+  );
+}
+
+function removeBookmarkFromPages(
+  old: BookmarkInfiniteData | undefined,
+  bookmarkId: number,
+): BookmarkInfiniteData | undefined {
+  if (!old) {
+    return old;
+  }
+
+  const removed = old.pages.some((page) =>
+    page.data.some((entry) => entry.id === bookmarkId),
+  );
+  if (!removed) {
+    return old;
+  }
+
+  return updateBookmarkPages(
+    old,
+    (page) => ({
+      ...page,
+      data: page.data.filter((entry) => entry.id !== bookmarkId),
+    }),
+    -1,
+  );
+}
+
+function resolveBookmarkFeedId(
+  bookmark: Bookmark,
+  queryClient: QueryClient,
+  uniqueFeedIdByName: Map<string, number>,
+): number {
+  if (bookmark.item_id && bookmark.item_id > 0) {
+    const item = getCachedItemById(queryClient, bookmark.item_id);
+    if (item) {
+      return item.feed_id;
+    }
+  }
+
+  return uniqueFeedIdByName.get(bookmark.feed_name) ?? 0;
+}
+
 export const bookmarkQueries = {
   list: () =>
-    queryOptions({
+    infiniteQueryOptions({
       queryKey: queryKeys.bookmarks.list(),
-      queryFn: async () => {
-        const res = await bookmarkAPI.list(100, 0);
-        return res.data;
+      queryFn: async ({ pageParam }) => {
+        const page = await bookmarkAPI.list(bookmarkPageSize, pageParam);
+        return {
+          ...page,
+          fetchedCount: page.data.length,
+        };
+      },
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages) => {
+        const fetched = allPages.reduce((count, page) => count + page.fetchedCount, 0);
+        return fetched < lastPage.total ? fetched : undefined;
       },
       staleTime: Number.POSITIVE_INFINITY,
     }),
 };
 
+export async function fetchBookmarkPage(offset: number): Promise<BookmarkPage> {
+  const page = await bookmarkAPI.list(bookmarkPageSize, offset);
+  return {
+    ...page,
+    fetchedCount: page.data.length,
+  };
+}
+
 export function useBookmarks() {
-  return useQuery(bookmarkQueries.list());
+  return useInfiniteQuery(bookmarkQueries.list());
 }
 
 export function useBookmarkLookup() {
-  const { data: bookmarks = [] } = useBookmarks();
-  const starredOverrides = useArticleSessionStore((s) => s.starredOverrides);
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useBookmarks();
+  const pages = data?.pages ?? [];
+  const bookmarks = useMemo(() => pages.flatMap((page) => page.data), [pages]);
+  const total = pages.at(-1)?.total ?? 0;
 
   const byArticleId = useMemo(
-    () => new Map(bookmarks.map((b) => [resolveBookmarkItemId(b), b])),
+    () => new Map(bookmarks.map((bookmark) => [resolveBookmarkItemId(bookmark), bookmark])),
     [bookmarks],
   );
 
   const isItemStarred = useCallback(
-    (itemId: number) => starredOverrides[itemId] ?? byArticleId.has(itemId),
-    [byArticleId, starredOverrides],
+    (itemId: number) => byArticleId.has(itemId),
+    [byArticleId],
   );
 
   const getBookmarkByItemId = useCallback(
@@ -49,36 +204,61 @@ export function useBookmarkLookup() {
     [byArticleId],
   );
 
-  return { bookmarks, isItemStarred, getBookmarkByItemId };
+  return {
+    bookmarks,
+    total,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isItemStarred,
+    getBookmarkByItemId,
+  };
 }
 
 export function useStarredItems(filters: {
   feedId: number | null;
   groupId: number | null;
 }) {
-  const { bookmarks } = useBookmarkLookup();
-  const { feeds, getFeedById, getFeedsByGroup } = useFeedLookup();
+  const queryClient = useQueryClient();
+  const bookmarksQuery = useBookmarkLookup();
+  const { feeds, getFeedsByGroup } = useFeedLookup();
 
-  return useMemo(() => {
-    let filtered = bookmarks;
-
-    if (filters.feedId) {
-      const feed = getFeedById(filters.feedId);
-      if (!feed) {
-        return [];
-      }
-      filtered = filtered.filter((b) => b.feed_name === feed.name);
-    } else if (filters.groupId) {
-      const feedNames = new Set(getFeedsByGroup(filters.groupId).map((f) => f.name));
-      filtered = filtered.filter((b) => feedNames.has(b.feed_name));
+  const articles = useMemo(() => {
+    const feedNameCounts = new Map<string, number>();
+    for (const feed of feeds) {
+      feedNameCounts.set(feed.name, (feedNameCounts.get(feed.name) ?? 0) + 1);
     }
 
-    const feedIdByName = new Map(feeds.map((f) => [f.name, f.id]));
+    const uniqueFeedIdByName = new Map(
+      feeds
+        .filter((feed) => (feedNameCounts.get(feed.name) ?? 0) === 1)
+        .map((feed) => [feed.name, feed.id] as const),
+    );
+    const groupFeedIds =
+      filters.groupId === null
+        ? null
+        : new Set(getFeedsByGroup(filters.groupId).map((feed) => feed.id));
+
+    let filtered = bookmarksQuery.bookmarks;
+
+    if (filters.feedId) {
+      filtered = filtered.filter(
+        (bookmark) =>
+          resolveBookmarkFeedId(bookmark, queryClient, uniqueFeedIdByName) ===
+          filters.feedId,
+      );
+    } else if (filters.groupId) {
+      filtered = filtered.filter((bookmark) => {
+        const feedId = resolveBookmarkFeedId(bookmark, queryClient, uniqueFeedIdByName);
+        return feedId > 0 && groupFeedIds?.has(feedId) === true;
+      });
+    }
 
     return filtered.map(
       (bookmark): Item => ({
         id: bookmark.item_id ?? -bookmark.id,
-        feed_id: feedIdByName.get(bookmark.feed_name) ?? 0,
+        feed_id: resolveBookmarkFeedId(bookmark, queryClient, uniqueFeedIdByName),
         guid: bookmark.link || `bookmark:${bookmark.id}`,
         title: bookmark.title,
         link: bookmark.link,
@@ -89,19 +269,26 @@ export function useStarredItems(filters: {
       }),
     );
   }, [
-    bookmarks,
+    bookmarksQuery.bookmarks,
+    feeds,
     filters.feedId,
     filters.groupId,
-    feeds,
-    getFeedById,
     getFeedsByGroup,
+    queryClient,
   ]);
+
+  return {
+    articles,
+    hasNextPage: bookmarksQuery.hasNextPage,
+    fetchNextPage: bookmarksQuery.fetchNextPage,
+    isFetchingNextPage: bookmarksQuery.isFetchingNextPage,
+    isLoading: bookmarksQuery.isLoading,
+  };
 }
 
 export function useCreateBookmark() {
   const qc = useQueryClient();
   const { getFeedById } = useFeedLookup();
-  const setStarredOverride = useArticleSessionStore((s) => s.setStarredOverride);
 
   return useMutation({
     mutationFn: async (item: Item) => {
@@ -117,30 +304,15 @@ export function useCreateBookmark() {
       return res.data!;
     },
     onSuccess: (bookmark) => {
-      const itemId = resolveBookmarkItemId(bookmark);
-      qc.setQueryData(
-        queryKeys.bookmarks.list(),
-        (old: Bookmark[] | undefined) => {
-          if (!old) return [bookmark];
-
-          const index = old.findIndex((b) => resolveBookmarkItemId(b) === itemId);
-          if (index === -1) {
-            return [bookmark, ...old];
-          }
-
-          const next = [...old];
-          next[index] = bookmark;
-          return next;
-        },
+      qc.setQueryData(queryKeys.bookmarks.list(), (old: BookmarkInfiniteData | undefined) =>
+        upsertBookmarkInPages(old, bookmark),
       );
-      setStarredOverride(itemId, true);
     },
   });
 }
 
 export function useDeleteBookmark() {
   const qc = useQueryClient();
-  const setStarredOverride = useArticleSessionStore((s) => s.setStarredOverride);
 
   return useMutation({
     mutationFn: async (bookmarkId: number) => {
@@ -148,14 +320,9 @@ export function useDeleteBookmark() {
       return bookmarkId;
     },
     onSuccess: (bookmarkId) => {
-      const bookmark = qc
-        .getQueryData<Bookmark[]>(queryKeys.bookmarks.list())
-        ?.find((b) => b.id === bookmarkId);
-      if (!bookmark) {
-        return;
-      }
-
-      setStarredOverride(resolveBookmarkItemId(bookmark), false);
+      qc.setQueryData(queryKeys.bookmarks.list(), (old: BookmarkInfiniteData | undefined) =>
+        removeBookmarkFromPages(old, bookmarkId),
+      );
     },
   });
 }

--- a/frontend/src/queries/bookmarks.ts
+++ b/frontend/src/queries/bookmarks.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from "react";
 import {
-  type QueryClient,
-  type InfiniteData,
   infiniteQueryOptions,
+  queryOptions,
   useInfiniteQuery,
   useMutation,
+  useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
 import {
@@ -12,8 +12,16 @@ import {
   type Bookmark,
   type Item,
   type ListAPIResponse,
+  type SavedBookmarkRef,
 } from "@/lib/api";
 import { countFetchedRows } from "./article-list-logic";
+import {
+  buildSavedBookmarkLookup,
+  resolveBookmarkFeedId,
+  resolveSavedBookmarkId,
+  removeSavedBookmarkRef,
+  upsertSavedBookmarkRef,
+} from "./bookmark-lookup-logic";
 import { useFeedLookup } from "./feeds";
 import { queryKeys } from "./keys";
 
@@ -21,7 +29,10 @@ type CachedItemPages = {
   pages: Array<{ data: Item[] }>;
 };
 
-function getCachedItemById(queryClient: QueryClient, itemId: number): Item | undefined {
+function getCachedItemById(
+  queryClient: ReturnType<typeof useQueryClient>,
+  itemId: number,
+): Item | undefined {
   const detailItem = queryClient.getQueryData<Item>(queryKeys.items.detail(itemId));
   if (detailItem) {
     return detailItem;
@@ -46,107 +57,19 @@ function resolveBookmarkItemId(bookmark: Bookmark): number {
 }
 
 export type BookmarkPage = ListAPIResponse<Bookmark> & { fetchedCount: number };
-type BookmarkInfiniteData = InfiniteData<BookmarkPage, number>;
 
 const bookmarkPageSize = 100;
 
-function updateBookmarkPages(
-  old: BookmarkInfiniteData | undefined,
-  updater: (page: BookmarkPage, pageIndex: number) => BookmarkPage,
-  totalDelta: number,
-): BookmarkInfiniteData | undefined {
-  if (!old) {
-    return old;
-  }
-
-  return {
-    ...old,
-    pages: old.pages.map((page, index) => ({
-      ...updater(page, index),
-      total: Math.max(0, page.total + totalDelta),
-      fetchedCount: page.fetchedCount,
-    })),
-  };
-}
-
-function upsertBookmarkInPages(
-  old: BookmarkInfiniteData | undefined,
-  bookmark: Bookmark,
-): BookmarkInfiniteData | undefined {
-  if (!old) {
-    return old;
-  }
-
-  const itemId = resolveBookmarkItemId(bookmark);
-  const exists = old.pages.some((page) =>
-    page.data.some(
-      (entry) => resolveBookmarkItemId(entry) === itemId || entry.id === bookmark.id,
-    ),
-  );
-
-  return updateBookmarkPages(
-    old,
-    (page, index) => {
-      const existingIndex = page.data.findIndex(
-        (entry) => resolveBookmarkItemId(entry) === itemId || entry.id === bookmark.id,
-      );
-      if (existingIndex !== -1) {
-        const data = [...page.data];
-        data[existingIndex] = bookmark;
-        return { ...page, data };
-      }
-
-      if (!exists && index === 0) {
-        return { ...page, data: [bookmark, ...page.data] };
-      }
-
-      return page;
-    },
-    exists ? 0 : 1,
-  );
-}
-
-function removeBookmarkFromPages(
-  old: BookmarkInfiniteData | undefined,
-  bookmarkId: number,
-): BookmarkInfiniteData | undefined {
-  if (!old) {
-    return old;
-  }
-
-  const removed = old.pages.some((page) =>
-    page.data.some((entry) => entry.id === bookmarkId),
-  );
-  if (!removed) {
-    return old;
-  }
-
-  return updateBookmarkPages(
-    old,
-    (page) => ({
-      ...page,
-      data: page.data.filter((entry) => entry.id !== bookmarkId),
-    }),
-    -1,
-  );
-}
-
-function resolveBookmarkFeedId(
-  bookmark: Bookmark,
-  queryClient: QueryClient,
-  uniqueFeedIdByName: Map<string, number>,
-): number {
-  if (bookmark.item_id && bookmark.item_id > 0) {
-    const item = getCachedItemById(queryClient, bookmark.item_id);
-    if (item) {
-      return item.feed_id;
-    }
-  }
-
-  return uniqueFeedIdByName.get(bookmark.feed_name) ?? 0;
-}
-
 export const bookmarkQueries = {
+  refs: () =>
+    queryOptions({
+      queryKey: queryKeys.bookmarks.refs(),
+      queryFn: async () => {
+        const res = await bookmarkAPI.listSavedItemRefs();
+        return res.data ?? [];
+      },
+      staleTime: Number.POSITIVE_INFINITY,
+    }),
   list: () =>
     infiniteQueryOptions({
       queryKey: queryKeys.bookmarks.list(),
@@ -178,18 +101,30 @@ export function useBookmarks() {
   return useInfiniteQuery(bookmarkQueries.list());
 }
 
+export function useSavedBookmarkRefs() {
+  return useQuery(bookmarkQueries.refs());
+}
+
 export function useBookmarkLookup() {
   const {
     data,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-    isLoading,
+    isLoading: isBookmarksLoading,
   } = useBookmarks();
+  const {
+    data: savedRefs = [],
+    isLoading: isSavedRefsLoading,
+  } = useSavedBookmarkRefs();
   const pages = data?.pages ?? [];
   const bookmarks = useMemo(() => pages.flatMap((page) => page.data), [pages]);
   const fetchedCount = useMemo(() => countFetchedRows(pages), [pages]);
-  const total = pages.at(-1)?.total ?? 0;
+  const total = pages.at(-1)?.total ?? savedRefs.length;
+  const savedLookup = useMemo(
+    () => buildSavedBookmarkLookup(savedRefs),
+    [savedRefs],
+  );
 
   const byArticleId = useMemo(
     () => new Map(bookmarks.map((bookmark) => [resolveBookmarkItemId(bookmark), bookmark])),
@@ -197,13 +132,19 @@ export function useBookmarkLookup() {
   );
 
   const isItemStarred = useCallback(
-    (itemId: number) => byArticleId.has(itemId),
-    [byArticleId],
+    (itemId: number) => resolveSavedBookmarkId({ savedLookup, loadedBookmarks: byArticleId, itemId }) !== undefined,
+    [byArticleId, savedLookup],
   );
 
   const getBookmarkByItemId = useCallback(
     (itemId: number) => byArticleId.get(itemId),
     [byArticleId],
+  );
+
+  const getSavedBookmarkIdByItemId = useCallback(
+    (itemId: number) =>
+      resolveSavedBookmarkId({ savedLookup, loadedBookmarks: byArticleId, itemId }),
+    [byArticleId, savedLookup],
   );
 
   return {
@@ -213,9 +154,10 @@ export function useBookmarkLookup() {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-    isLoading,
+    isLoading: isBookmarksLoading || isSavedRefsLoading,
     isItemStarred,
     getBookmarkByItemId,
+    getSavedBookmarkIdByItemId,
   };
 }
 
@@ -247,13 +189,22 @@ export function useStarredItems(filters: {
 
     if (filters.feedId) {
       filtered = filtered.filter(
-        (bookmark) =>
-          resolveBookmarkFeedId(bookmark, queryClient, uniqueFeedIdByName) ===
-          filters.feedId,
+        (bookmark) => {
+          const feedId = resolveBookmarkFeedId({
+            bookmark,
+            uniqueFeedIdByName,
+            getCachedFeedId: (itemId) => getCachedItemById(queryClient, itemId)?.feed_id,
+          });
+          return feedId === filters.feedId;
+        },
       );
     } else if (filters.groupId) {
       filtered = filtered.filter((bookmark) => {
-        const feedId = resolveBookmarkFeedId(bookmark, queryClient, uniqueFeedIdByName);
+        const feedId = resolveBookmarkFeedId({
+          bookmark,
+          uniqueFeedIdByName,
+          getCachedFeedId: (itemId) => getCachedItemById(queryClient, itemId)?.feed_id,
+        });
         return feedId > 0 && groupFeedIds?.has(feedId) === true;
       });
     }
@@ -261,7 +212,11 @@ export function useStarredItems(filters: {
     return filtered.map(
       (bookmark): Item => ({
         id: bookmark.item_id ?? -bookmark.id,
-        feed_id: resolveBookmarkFeedId(bookmark, queryClient, uniqueFeedIdByName),
+        feed_id: resolveBookmarkFeedId({
+          bookmark,
+          uniqueFeedIdByName,
+          getCachedFeedId: (itemId) => getCachedItemById(queryClient, itemId)?.feed_id,
+        }),
         guid: bookmark.link || `bookmark:${bookmark.id}`,
         title: bookmark.title,
         link: bookmark.link,
@@ -277,7 +232,6 @@ export function useStarredItems(filters: {
     filters.feedId,
     filters.groupId,
     getFeedsByGroup,
-    queryClient,
   ]);
 
   return {
@@ -307,9 +261,10 @@ export function useCreateBookmark() {
       return res.data!;
     },
     onSuccess: (bookmark) => {
-      qc.setQueryData(queryKeys.bookmarks.list(), (old: BookmarkInfiniteData | undefined) =>
-        upsertBookmarkInPages(old, bookmark),
+      qc.setQueryData(queryKeys.bookmarks.refs(), (old: SavedBookmarkRef[] | undefined) =>
+        upsertSavedBookmarkRef(old, bookmark),
       );
+      void qc.invalidateQueries({ queryKey: queryKeys.bookmarks.list() });
     },
   });
 }
@@ -323,9 +278,10 @@ export function useDeleteBookmark() {
       return bookmarkId;
     },
     onSuccess: (bookmarkId) => {
-      qc.setQueryData(queryKeys.bookmarks.list(), (old: BookmarkInfiniteData | undefined) =>
-        removeBookmarkFromPages(old, bookmarkId),
+      qc.setQueryData(queryKeys.bookmarks.refs(), (old: SavedBookmarkRef[] | undefined) =>
+        removeSavedBookmarkRef(old, bookmarkId),
       );
+      void qc.invalidateQueries({ queryKey: queryKeys.bookmarks.list() });
     },
   });
 }

--- a/frontend/src/queries/items.ts
+++ b/frontend/src/queries/items.ts
@@ -1,12 +1,12 @@
 import {
   infiniteQueryOptions,
   queryOptions,
+  type InfiniteData,
   type QueryClient,
   useInfiniteQuery,
   useMutation,
   useQuery,
   useQueryClient,
-  type InfiniteData,
 } from "@tanstack/react-query";
 import { itemAPI, type Feed, type Item, type ListItemsParams } from "@/lib/api";
 import {
@@ -17,7 +17,7 @@ import {
 } from "./keys";
 import { usePreferencesStore } from "@/store";
 
-type ItemListResponse = Awaited<ReturnType<typeof itemAPI.list>>;
+export type ItemListResponse = Awaited<ReturnType<typeof itemAPI.list>>;
 type ItemsInfiniteData = InfiniteData<ItemListResponse, number>;
 type ItemsMutationContext = {
   prevItemLists: Array<[readonly unknown[], ItemsInfiniteData | undefined]>;
@@ -67,6 +67,14 @@ export const itemQueries = {
       },
     }),
 };
+
+export async function fetchItemsPage(
+  filters: ItemFilters,
+  pageSize: number,
+  offset: number,
+): Promise<ItemListResponse> {
+  return itemAPI.list(buildListItemsParams(normalizeItemFilters(filters), offset, pageSize));
+}
 
 export function useItems(filters: ItemFilters) {
   const articlePageSize = usePreferencesStore((state) => state.articlePageSize);

--- a/frontend/src/queries/keys.ts
+++ b/frontend/src/queries/keys.ts
@@ -40,5 +40,6 @@ export const queryKeys = {
   bookmarks: {
     all: ["bookmarks"] as const,
     list: () => [...queryKeys.bookmarks.all, "list"] as const,
+    refs: () => [...queryKeys.bookmarks.all, "refs"] as const,
   },
 };

--- a/frontend/src/store/article-session.ts
+++ b/frontend/src/store/article-session.ts
@@ -1,24 +1,85 @@
 import { create } from "zustand";
 
+export interface ArticleListOverlay {
+  readOverrides: Record<number, boolean>;
+  starOverrides: Record<number, boolean>;
+  stickyVisibleIds: Record<number, true>;
+}
+
+export function createEmptyArticleListOverlay(): ArticleListOverlay {
+  return {
+  readOverrides: {},
+  starOverrides: {},
+  stickyVisibleIds: {},
+  };
+}
+
 interface ArticleSessionState {
-  starredOverrides: Record<number, boolean>;
-  setStarredOverride: (itemId: number, starred: boolean) => void;
-  clearStarredOverride: (itemId: number) => void;
+  overlays: Record<string, ArticleListOverlay>;
+  setReadOverride: (contextKey: string, itemId: number, unread: boolean) => void;
+  setStarOverride: (contextKey: string, itemId: number, starred: boolean) => void;
+  keepVisible: (contextKey: string, itemId: number) => void;
+  setOverlay: (contextKey: string, overlay: ArticleListOverlay | undefined) => void;
+  clearContext: (contextKey: string) => void;
 }
 
 export const useArticleSessionStore = create<ArticleSessionState>((set) => ({
-  starredOverrides: {},
-  setStarredOverride: (itemId, starred) =>
+  overlays: {},
+  setReadOverride: (contextKey, itemId, unread) =>
     set((state) => ({
-      starredOverrides: {
-        ...state.starredOverrides,
-        [itemId]: starred,
+      overlays: {
+        ...state.overlays,
+        [contextKey]: {
+          ...(state.overlays[contextKey] ?? createEmptyArticleListOverlay()),
+          readOverrides: {
+            ...(state.overlays[contextKey]?.readOverrides ?? {}),
+            [itemId]: unread,
+          },
+        },
       },
     })),
-  clearStarredOverride: (itemId) =>
+  setStarOverride: (contextKey, itemId, starred) =>
+    set((state) => ({
+      overlays: {
+        ...state.overlays,
+        [contextKey]: {
+          ...(state.overlays[contextKey] ?? createEmptyArticleListOverlay()),
+          starOverrides: {
+            ...(state.overlays[contextKey]?.starOverrides ?? {}),
+            [itemId]: starred,
+          },
+        },
+      },
+    })),
+  keepVisible: (contextKey, itemId) =>
+    set((state) => ({
+      overlays: {
+        ...state.overlays,
+        [contextKey]: {
+          ...(state.overlays[contextKey] ?? createEmptyArticleListOverlay()),
+          stickyVisibleIds: {
+            ...(state.overlays[contextKey]?.stickyVisibleIds ?? {}),
+            [itemId]: true,
+          },
+        },
+      },
+    })),
+  setOverlay: (contextKey, overlay) =>
     set((state) => {
-      const next = { ...state.starredOverrides };
-      delete next[itemId];
-      return { starredOverrides: next };
+      const next = { ...state.overlays };
+
+      if (overlay) {
+        next[contextKey] = overlay;
+      } else {
+        delete next[contextKey];
+      }
+
+      return { overlays: next };
+    }),
+  clearContext: (contextKey) =>
+    set((state) => {
+      const next = { ...state.overlays };
+      delete next[contextKey];
+      return { overlays: next };
     }),
 }));

--- a/frontend/src/store/article-session.ts
+++ b/frontend/src/store/article-session.ts
@@ -1,16 +1,19 @@
 import { create } from "zustand";
+import type { Item } from "@/lib/api";
 
 export interface ArticleListOverlay {
   readOverrides: Record<number, boolean>;
   starOverrides: Record<number, boolean>;
   stickyVisibleIds: Record<number, true>;
+  stickyArticles: Record<number, Item>;
 }
 
 export function createEmptyArticleListOverlay(): ArticleListOverlay {
   return {
-  readOverrides: {},
-  starOverrides: {},
-  stickyVisibleIds: {},
+    readOverrides: {},
+    starOverrides: {},
+    stickyVisibleIds: {},
+    stickyArticles: {},
   };
 }
 
@@ -19,6 +22,7 @@ interface ArticleSessionState {
   setReadOverride: (contextKey: string, itemId: number, unread: boolean) => void;
   setStarOverride: (contextKey: string, itemId: number, starred: boolean) => void;
   keepVisible: (contextKey: string, itemId: number) => void;
+  setStickyArticle: (contextKey: string, article: Item) => void;
   setOverlay: (contextKey: string, overlay: ArticleListOverlay | undefined) => void;
   clearContext: (contextKey: string) => void;
 }
@@ -60,6 +64,19 @@ export const useArticleSessionStore = create<ArticleSessionState>((set) => ({
           stickyVisibleIds: {
             ...(state.overlays[contextKey]?.stickyVisibleIds ?? {}),
             [itemId]: true,
+          },
+        },
+      },
+    })),
+  setStickyArticle: (contextKey, article) =>
+    set((state) => ({
+      overlays: {
+        ...state.overlays,
+        [contextKey]: {
+          ...(state.overlays[contextKey] ?? createEmptyArticleListOverlay()),
+          stickyArticles: {
+            ...(state.overlays[contextKey]?.stickyArticles ?? {}),
+            [article.id]: article,
           },
         },
       },


### PR DESCRIPTION
## Summary
- add a context-aware article list overlay so unread and starred views can keep modified rows visible without breaking list state
- convert starred data to paginated bookmarks and adjust unread/starred load-more offsets after local membership-changing actions
- unify article list and drawer behavior, and add helper-level regression coverage for starred pagination and sticky visibility

## Test Plan
- [x] `cd frontend && node --test scripts/article-list-logic.test.ts`
- [x] `cd frontend && npx tsr generate && npx tsc -b --noEmit`
- [x] `cd backend && go test ./...`