### PR TITLE
Add PikaPods in 1-click deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ See [Contributing](./CONTRIBUTING.md).
 
 - [Deploy on Fly.io](./fly.toml)
 - [Deploy on Railway](https://railway.com/template/XSPFK0?referralCode=milo) (community maintained)
+- [Deploy on PikaPods](https://www.pikapods.com/pods?run=fusion)
 </details>
 
 ## Configuration


### PR DESCRIPTION
PikaPods is a popular platform for providing 1-click deployment for self-hosted open source software. They also offer Fusion as 1-click deployment. This should help Fusion users.