### PR TITLE
fix: menu interactions not working after updating from Radix to BaseUI

### DIFF
--- a/frontend/src/routes/feeds.lazy.tsx
+++ b/frontend/src/routes/feeds.lazy.tsx
@@ -269,7 +269,7 @@ function FeedsPage() {
                   (key) => (
                     <DropdownMenuItem
                       key={key}
-                      onSelect={() => setStatusFilter(key)}
+                      onClick={() => setStatusFilter(key)}
                     >
                       {statusFilterLabels[key]}
                     </DropdownMenuItem>
@@ -290,11 +290,11 @@ function FeedsPage() {
                 }
               />
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onSelect={() => setAddFeedOpen(true)}>
+                <DropdownMenuItem onClick={() => setAddFeedOpen(true)}>
                   <Rss className="mr-2 h-4 w-4" />
                   {t("feed.add.title")}
                 </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => setAddGroupOpen(true)}>
+                <DropdownMenuItem onClick={() => setAddGroupOpen(true)}>
                   <Folder className="mr-2 h-4 w-4" />
                   {t("group.add.title")}
                 </DropdownMenuItem>


### PR DESCRIPTION
Fixes regression introduced in 7b61014b55b47af9065544f438d8298db746d59d. The cause was that BaseUI uses `onClick` instead of `onSelect`.

Adding feed works again with this PR.
<img width="197" height="132" alt="image" src="https://github.com/user-attachments/assets/84c4fc53-70c1-4c74-b29b-20e38777b5dd" />
