### PR TITLE
fix(frontend): correct Base UI Select, Button, and dialog usage

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@fontsource-variable/geist": "^5.3.0",
     "@fontsource-variable/geist-mono": "^5.3.0",
     "@fontsource-variable/inter": "^5.3.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.6.0
-        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fontsource-variable/geist':
         specifier: ^5.3.0
         version: 5.3.0
@@ -253,8 +253,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.6.0':
-    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -270,8 +270,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.3.1':
-    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -3280,10 +3280,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.6.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@base-ui/utils': 0.3.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/utils': 0.2.12
       react: 19.2.8
@@ -3292,7 +3292,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@base-ui/utils@0.3.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.12

--- a/frontend/src/components/article/article-drawer.tsx
+++ b/frontend/src/components/article/article-drawer.tsx
@@ -184,6 +184,7 @@ export function ArticleDrawer() {
                   {starred ? t("article.action.unstar") : t("article.action.star")}
                 </Button>
                 <Button
+                  nativeButton={!safeArticleLink}
                   render={
                     safeArticleLink ? (
                       <a

--- a/frontend/src/components/article/article-drawer.tsx
+++ b/frontend/src/components/article/article-drawer.tsx
@@ -8,7 +8,7 @@ import {
   X,
 } from "lucide-react";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useUrlState } from "@/hooks/use-url-state";
 import type { Item } from "@/lib/api";
@@ -25,7 +25,7 @@ import {
 import { useArticleList } from "@/hooks/use-article-list";
 import { useArticleNavigation } from "@/hooks/use-keyboard";
 import { useI18n } from "@/lib/i18n";
-import { formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 import { processArticleContent } from "@/lib/content";
 import { getFaviconUrl } from "@/lib/api/favicon";
 import { FeedFavicon } from "@/components/feed/feed-favicon";
@@ -183,26 +183,30 @@ export function ArticleDrawer() {
                   />
                   {starred ? t("article.action.unstar") : t("article.action.star")}
                 </Button>
-                <Button
-                  nativeButton={!safeArticleLink}
-                  render={
-                    safeArticleLink ? (
-                      <a
-                        href={safeArticleLink}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      />
-                    ) : undefined
-                  }
-                  variant="outline"
-                  size="sm"
-                  onClick={safeArticleLink ? undefined : handleOpenOriginal}
-                  disabled={!safeArticleLink}
-                  className="h-auto gap-1.5 px-2.5 py-1.5 text-[13px] font-medium text-muted-foreground"
-                >
-                  <ExternalLink className="h-4 w-4" />
-                  {t("article.action.original")}
-                </Button>
+                {safeArticleLink ? (
+                  <a
+                    href={safeArticleLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={cn(
+                      buttonVariants({ variant: "outline", size: "sm" }),
+                      "h-auto gap-1.5 px-2.5 py-1.5 text-[13px] font-medium text-muted-foreground",
+                    )}
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    {t("article.action.original")}
+                  </a>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled
+                    className="h-auto gap-1.5 px-2.5 py-1.5 text-[13px] font-medium text-muted-foreground"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    {t("article.action.original")}
+                  </Button>
+                )}
               </div>
 
               <SheetTitle className="sr-only">{article.title}</SheetTitle>

--- a/frontend/src/components/article/article-item.tsx
+++ b/frontend/src/components/article/article-item.tsx
@@ -140,6 +140,7 @@ export function ArticleItem({
         </Button>
         {safeArticleLink ? (
           <Button
+            nativeButton={false}
             render={
               <a
                 href={safeArticleLink}

--- a/frontend/src/components/article/article-item.tsx
+++ b/frontend/src/components/article/article-item.tsx
@@ -1,5 +1,5 @@
 import { Circle, CircleCheck, Star, ExternalLink } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { useI18n } from "@/lib/i18n";
 import { cn, formatDate, extractSummary } from "@/lib/utils";
 import type { Item } from "@/lib/api";
@@ -139,24 +139,17 @@ export function ArticleItem({
           />
         </Button>
         {safeArticleLink ? (
-          <Button
-            nativeButton={false}
-            render={
-              <a
-                href={safeArticleLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-              />
-            }
-            variant="ghost"
-            size="icon-sm"
-            className="bg-muted"
+          <a
+            href={safeArticleLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }), "bg-muted")}
             aria-label={t("article.action.openInBrowser")}
             title={t("article.action.openInBrowser")}
           >
             <ExternalLink className="text-muted-foreground" />
-          </Button>
+          </a>
         ) : (
           <Button
             variant="ghost"

--- a/frontend/src/components/feed/add-feed-dialog.tsx
+++ b/frontend/src/components/feed/add-feed-dialog.tsx
@@ -48,6 +48,10 @@ export function AddFeedDialog() {
   const [isValidating, setIsValidating] = useState(false);
   const [detectedFeeds, setDetectedFeeds] = useState<DiscoveredFeed[]>([]);
   const [isFeedSelectOpen, setIsFeedSelectOpen] = useState(false);
+  const groupItems = groups.map((group) => ({
+    value: group.id.toString(),
+    label: group.name,
+  }));
 
   const resetForm = () => {
     setUrl("");
@@ -217,14 +221,20 @@ export function AddFeedDialog() {
               <label className="text-[13px] font-medium" id="add-feed-group-label">
                 {t("feed.add.groupLabel")}
               </label>
-              <Select value={groupId} onValueChange={(v) => { if (v) setGroupId(v); }}>
+              <Select
+                items={groupItems}
+                value={groupId || null}
+                onValueChange={(v) => {
+                  if (v) setGroupId(v);
+                }}
+              >
                 <SelectTrigger className="h-10" aria-labelledby="add-feed-group-label">
                   <SelectValue placeholder={t("feed.add.groupPlaceholder")} />
                 </SelectTrigger>
                 <SelectContent>
-                  {groups.map((group) => (
-                    <SelectItem key={group.id} value={group.id.toString()}>
-                      {group.name}
+                  {groupItems.map((group) => (
+                    <SelectItem key={group.value} value={group.value}>
+                      {group.label}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/components/feed/edit-feed-dialog.tsx
+++ b/frontend/src/components/feed/edit-feed-dialog.tsx
@@ -57,6 +57,10 @@ export function EditFeedDialog() {
     useState(false);
   const urlInputRef = useRef<HTMLInputElement>(null);
   const isMobile = useIsMobile();
+  const groupItems = groups.map((group) => ({
+    value: group.id.toString(),
+    label: group.name,
+  }));
 
   useEffect(() => {
     if (editingFeed) {
@@ -253,14 +257,20 @@ export function EditFeedDialog() {
               <label className="text-[13px] font-medium" id="edit-feed-group-label">
                 {t("feed.add.groupLabel")}
               </label>
-              <Select value={groupId} onValueChange={(v) => { if (v) setGroupId(v); }}>
+              <Select
+                items={groupItems}
+                value={groupId || null}
+                onValueChange={(v) => {
+                  if (v) setGroupId(v);
+                }}
+              >
                 <SelectTrigger className="h-10" aria-labelledby="edit-feed-group-label">
                   <SelectValue placeholder={t("feed.add.groupPlaceholder")} />
                 </SelectTrigger>
                 <SelectContent>
-                  {groups.map((group) => (
-                    <SelectItem key={group.id} value={group.id.toString()}>
-                      {group.name}
+                  {groupItems.map((group) => (
+                    <SelectItem key={group.value} value={group.value}>
+                      {group.label}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/components/search/search-dialog.tsx
+++ b/frontend/src/components/search/search-dialog.tsx
@@ -114,11 +114,11 @@ export function SearchDialog() {
 
   return (
     <Dialog open={isSearchOpen} onOpenChange={handleOpenChange}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{t("search.title")}</DialogTitle>
-        <DialogDescription>{t("search.description")}</DialogDescription>
-      </DialogHeader>
       <DialogContent className="overflow-hidden p-0" showCloseButton={false}>
+        <DialogHeader className="sr-only">
+          <DialogTitle>{t("search.title")}</DialogTitle>
+          <DialogDescription>{t("search.description")}</DialogDescription>
+        </DialogHeader>
         <Command
           shouldFilter={false}
           className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"

--- a/frontend/src/components/settings/settings-dialog.tsx
+++ b/frontend/src/components/settings/settings-dialog.tsx
@@ -63,6 +63,20 @@ function AppearanceContent() {
   const { locale, articlePageSize, setLocale, setArticlePageSize } =
     usePreferencesStore();
 
+  const localeItems = supportedLocales.map((localeCode) => ({
+    value: localeCode,
+    label: localeLabels[localeCode] ?? localeCode,
+  }));
+  const articlePageSizeItems = articlePageSizeOptions.map((size) => ({
+    value: size.toString(),
+    label: String(size),
+  }));
+  const themeItems = [
+    { value: "light", label: t("settings.theme.light") },
+    { value: "dark", label: t("settings.theme.dark") },
+    { value: "system", label: t("settings.theme.system") },
+  ];
+
   return (
     <div className="space-y-5">
       {/* Language */}
@@ -73,14 +87,20 @@ function AppearanceContent() {
             {t("settings.language.description")}
           </p>
         </div>
-        <Select value={locale} onValueChange={(v) => { if (v) setLocale(v); }}>
+        <Select
+          items={localeItems}
+          value={locale}
+          onValueChange={(v) => {
+            if (v) setLocale(v);
+          }}
+        >
           <SelectTrigger className="w-auto gap-2 border-border">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {supportedLocales.map((localeCode) => (
-              <SelectItem key={localeCode} value={localeCode}>
-                {localeLabels[localeCode] ?? localeCode}
+            {localeItems.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
               </SelectItem>
             ))}
           </SelectContent>
@@ -98,6 +118,7 @@ function AppearanceContent() {
           </p>
         </div>
         <Select
+          items={articlePageSizeItems}
           value={articlePageSize.toString()}
           onValueChange={(value) => {
             if (!value) return;
@@ -111,9 +132,9 @@ function AppearanceContent() {
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {articlePageSizeOptions.map((size) => (
-              <SelectItem key={size} value={size.toString()}>
-                {size}
+            {articlePageSizeItems.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
               </SelectItem>
             ))}
           </SelectContent>
@@ -128,14 +149,22 @@ function AppearanceContent() {
             {t("settings.theme.description")}
           </p>
         </div>
-        <Select value={theme} onValueChange={(v) => { if (v) setTheme(v); }}>
+        <Select
+          items={themeItems}
+          value={theme}
+          onValueChange={(v) => {
+            if (v) setTheme(v);
+          }}
+        >
           <SelectTrigger className="w-auto gap-2 border-border">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="light">{t("settings.theme.light")}</SelectItem>
-            <SelectItem value="dark">{t("settings.theme.dark")}</SelectItem>
-            <SelectItem value="system">{t("settings.theme.system")}</SelectItem>
+            {themeItems.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>
@@ -216,6 +245,7 @@ function AboutContent() {
         <Button
           variant="outline"
           size="sm"
+          nativeButton={false}
           render={
             <a
               href="https://github.com/0x2e/fusion"
@@ -230,6 +260,7 @@ function AboutContent() {
         <Button
           variant="outline"
           size="sm"
+          nativeButton={false}
           render={
             <a
               href="https://github.com/0x2e/fusion/issues"

--- a/frontend/src/components/settings/settings-dialog.tsx
+++ b/frontend/src/components/settings/settings-dialog.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "next-themes";
 import { toast } from "sonner";
 import { Bug, Download, Info, Keyboard, Palette } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -242,36 +242,24 @@ function AboutContent() {
               : t("settings.about.install")}
           </Button>
         )}
-        <Button
-          variant="outline"
-          size="sm"
-          nativeButton={false}
-          render={
-            <a
-              href="https://github.com/0x2e/fusion"
-              target="_blank"
-              rel="noopener noreferrer"
-            />
-          }
+        <a
+          href="https://github.com/0x2e/fusion"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={buttonVariants({ variant: "outline", size: "sm" })}
         >
           <GithubIcon className="h-4 w-4" />
           {t("settings.about.github")}
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          nativeButton={false}
-          render={
-            <a
-              href="https://github.com/0x2e/fusion/issues"
-              target="_blank"
-              rel="noopener noreferrer"
-            />
-          }
+        </a>
+        <a
+          href="https://github.com/0x2e/fusion/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={buttonVariants({ variant: "outline", size: "sm" })}
         >
           <Bug className="h-4 w-4" />
           {t("settings.about.reportIssue")}
-        </Button>
+        </a>
       </div>
       <p className="mt-auto text-xs text-muted-foreground">
         {t("settings.about.license")}


### PR DESCRIPTION
## Summary

After the Radix-to-Base UI migration, several call sites still used Radix-era patterns. This branch fixes those usages and upgrades `@base-ui/react` to 1.7.0.

- Pass `items` to Base UI Select so triggers show labels instead of raw values (feed group names, settings language/theme).
- Keep the search dialog title and description inside the dialog popup.
- Render external links as styled `<a>` elements with `buttonVariants`, not `Button` with `render`. Base UI Button forces `role="button"` even with `nativeButton={false}`.
- Upgrade `@base-ui/react` from 1.6.0 to 1.7.0.

## Test plan

- [ ] Open a feed edit dialog and confirm the group field shows the group name, not the id.
- [ ] Open add-feed, pick a group, and confirm the trigger keeps showing the name.
- [ ] Open Settings and confirm language/theme labels (not `en` / `light`).
- [ ] Click GitHub, report-issue, and open-in-browser / original-article links. They should behave as real links (new tab, middle-click, screen reader says link).
- [ ] Open search (`Cmd+K`) and confirm the dialog still works.