### PR TITLE
feat(frontend): support details/summary in article content

### DIFF
--- a/frontend/src/lib/content.ts
+++ b/frontend/src/lib/content.ts
@@ -109,6 +109,9 @@ function sanitizeImages(root: DocumentFragment, articleUrl: string | null): void
 function removeEmptyWrappers(root: DocumentFragment): void {
   const elements = Array.from(root.querySelectorAll("*")).reverse();
   for (const element of elements) {
+    // An empty <summary> must survive: a <details> without one has no
+    // disclosure toggle and its content becomes unreachable.
+    if (element.tagName.toLowerCase() === "summary") continue;
     if (isEmptyElement(element)) {
       element.remove();
     }

--- a/frontend/src/lib/content.ts
+++ b/frontend/src/lib/content.ts
@@ -35,9 +35,11 @@ const ALLOWED_TAGS = [
   "hr",
   "figure",
   "figcaption",
+  "details",
+  "summary",
 ];
 
-const ALLOWED_ATTR = ["href", "src", "alt", "title", "class", "target", "rel"];
+const ALLOWED_ATTR = ["href", "src", "alt", "title", "class", "target", "rel", "open"];
 
 // Tags that are meaningful even when empty
 const SELF_CLOSING_TAGS = new Set(["br", "hr", "img", "td", "th", "li"]);

--- a/frontend/src/typeset.css
+++ b/frontend/src/typeset.css
@@ -322,6 +322,15 @@
       margin-block-start: calc(var(--typeset-flow) * 2.4);
       margin-block-end: 0;
     }
+
+    /* Collapsible sections. */
+    &:where(details) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(summary) {
+      cursor: pointer;
+    }
     &:where(hr + h1, hr + h2, hr + h3, hr + h4) {
       margin-block-start: var(--typeset-flow);
     }


### PR DESCRIPTION
Closes #258

## Changes
- Add `details` and `summary` to the DOMPurify tag allowlist in `frontend/src/lib/content.ts`, plus the `open` attribute so feeds that ship `<details open>` keep their expanded state.
- Exempt empty `<summary>` from the empty-wrapper removal pass — a `<details>` without a summary has no disclosure toggle and its content becomes unreachable.
- Minimal typeset styles for `details`/`summary` matching the existing flow rhythm.

Steam News-style feeds with collapsible changelogs/patch notes now render as native expandable sections.

Verified with `npx tsc -b --noEmit` (no test suite exists for the frontend).